### PR TITLE
plugins: expose Plugin interface publicly

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -1,0 +1,15 @@
+package plugin
+
+import (
+	"context"
+
+	"github.com/vultisig/mobile-tss-lib/tss"
+	"github.com/vultisig/verifier/types"
+)
+
+type Plugin interface {
+	ValidatePluginPolicy(policyDoc types.PluginPolicy) error
+	ProposeTransactions(policy types.PluginPolicy) ([]types.PluginKeysignRequest, error)
+	ValidateProposedTransactions(policy types.PluginPolicy, txs []types.PluginKeysignRequest) error
+	SigningComplete(ctx context.Context, signature tss.KeysignResponse, signRequest types.PluginKeysignRequest, policy types.PluginPolicy) error
+}


### PR DESCRIPTION
Resolved #15

This brings in the plugin interface to the verifier.

We want this to be a top-level publicly accessible interface as it defines the exact functionality that must be implemented by a package to be considered a plugin.

Anyone who implements these (the list will grow) will be more or less ready to be a plugin for vultisig - they will still have to make a PR to the verifier to implement some verification logic and register a plugin ID, but the core functionality is encapsulated in this interface.

I have removed the `embed.FS` option from the previous repo since that is no longer required with the planned shift to a config-schema based UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new plugin interface to support customizable plugin behaviors, including policy validation, transaction proposal, transaction validation, and handling of completed signing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->