### PR TITLE
address: return public key data and support EdDSA derivations through public entrypoint

### DIFF
--- a/address/address.go
+++ b/address/address.go
@@ -8,42 +8,61 @@ import (
 	"github.com/vultisig/verifier/common"
 )
 
-// GetAddress returns the address for the given public key and chain.
-func GetAddress(rootHexPublicKey string, rootChainCode string, chain common.Chain) (string, error) {
-	hexPublicKey, err := tss.GetDerivedPubKey(rootHexPublicKey, rootChainCode, chain.GetDerivePath(), chain.IsEdDSA())
-	if err != nil {
-		return "", fmt.Errorf("failed to derive public key: %w", err)
+// GetAddress returns the address, public key, isEdDSA, and error for the given public key and chain.
+func GetAddress(rootHexPublicKey string, rootChainCode string, chain common.Chain) (address string, publicKey string, isEdDSA bool, err error) {
+	if !chain.IsEdDSA() {
+		publicKey, err = tss.GetDerivedPubKey(rootHexPublicKey, rootChainCode, chain.GetDerivePath(), chain.IsEdDSA())
+		if err != nil {
+			return "", "", false, fmt.Errorf("failed to derive public key: %w", err)
+		}
+	} else {
+		publicKey = rootHexPublicKey
 	}
+
 	switch chain {
 	case common.Bitcoin:
-		return GetBitcoinAddress(hexPublicKey)
+		address, err = GetBitcoinAddress(publicKey)
+		return address, publicKey, chain.IsEdDSA(), err
 	case common.BitcoinCash:
-		return GetBitcoinCashAddress(hexPublicKey)
+		address, err = GetBitcoinCashAddress(publicKey)
+		return address, publicKey, chain.IsEdDSA(), err
 	case common.Litecoin:
-		return GetLitecoinAddress(hexPublicKey)
+		address, err = GetLitecoinAddress(publicKey)
+		return address, publicKey, chain.IsEdDSA(), err
 	case common.GaiaChain:
-		return GetBech32Address(hexPublicKey, `cosmos`)
+		address, err = GetBech32Address(publicKey, `cosmos`)
+		return address, publicKey, chain.IsEdDSA(), err
 	case common.THORChain:
-		return GetBech32Address(hexPublicKey, `thor`)
+		address, err = GetBech32Address(publicKey, `thor`)
+		return address, publicKey, chain.IsEdDSA(), err
 	case common.MayaChain:
-		return GetBech32Address(hexPublicKey, `maya`)
+		address, err = GetBech32Address(publicKey, `maya`)
+		return address, publicKey, chain.IsEdDSA(), err
 	case common.Kujira:
-		return GetBech32Address(hexPublicKey, `kujira`)
+		address, err = GetBech32Address(publicKey, `kujira`)
+		return address, publicKey, chain.IsEdDSA(), err
 	case common.Dydx:
-		return GetBech32Address(hexPublicKey, `dydx`)
+		address, err = GetBech32Address(publicKey, `dydx`)
+		return address, publicKey, chain.IsEdDSA(), err
 	case common.TerraClassic, common.Terra:
-		return GetBech32Address(hexPublicKey, `terra`)
+		address, err = GetBech32Address(publicKey, `terra`)
+		return address, publicKey, chain.IsEdDSA(), err
 	case common.Osmosis:
-		return GetBech32Address(hexPublicKey, `osmosis`)
+		address, err = GetBech32Address(publicKey, `osmosis`)
+		return address, publicKey, chain.IsEdDSA(), err
 	case common.Noble:
-		return GetBech32Address(hexPublicKey, `noble`)
+		address, err = GetBech32Address(publicKey, `noble`)
+		return address, publicKey, chain.IsEdDSA(), err
 	case common.Arbitrum, common.Base, common.BscChain, common.Ethereum, common.Polygon, common.Blast, common.Avalanche, common.Optimism, common.CronosChain, common.Zksync:
-		return GetEVMAddress(hexPublicKey)
+		address, err = GetEVMAddress(publicKey)
+		return address, publicKey, chain.IsEdDSA(), err
 	case common.Sui:
-		return GetSuiAddress(hexPublicKey)
+		address, err = GetSuiAddress(publicKey)
+		return address, publicKey, chain.IsEdDSA(), err
 	case common.Solana:
-		return GetSolAddress(hexPublicKey)
+		address, err = GetSolAddress(publicKey)
+		return address, publicKey, chain.IsEdDSA(), err
 	default:
-		return "", fmt.Errorf("unsupported chain: %s", chain)
+		return "", "", false, fmt.Errorf("unsupported chain: %s", chain)
 	}
 }

--- a/address/address.go
+++ b/address/address.go
@@ -10,6 +10,10 @@ import (
 
 // GetAddress returns the address, public key, isEdDSA, and error for the given public key and chain.
 func GetAddress(rootHexPublicKey string, rootChainCode string, chain common.Chain) (address string, publicKey string, isEdDSA bool, err error) {
+	if len(rootHexPublicKey) != 66 && len(rootHexPublicKey) != 64 {
+		return "", "", false, fmt.Errorf("invalid public key: %s", rootHexPublicKey)
+	}
+
 	if !chain.IsEdDSA() {
 		publicKey, err = tss.GetDerivedPubKey(rootHexPublicKey, rootChainCode, chain.GetDerivePath(), chain.IsEdDSA())
 		if err != nil {

--- a/address/address_test.go
+++ b/address/address_test.go
@@ -5,34 +5,58 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/vultisig/mobile-tss-lib/tss"
 	"github.com/vultisig/verifier/common"
 )
 
 func TestGetAddress(t *testing.T) {
 	tests := []struct {
-		name  string
-		chain common.Chain
-		want  string
+		name     string
+		chain    common.Chain
+		want     string
+		inputKey string
+		isEdDSA  bool
 	}{
 		{
-			name:  "BitcoinCash",
-			chain: common.BitcoinCash,
-			want:  "qzsvzzkwt9tjl4lv5c4zwks2nse50gqq6scda6xp00",
+			name:     "BitcoinCash",
+			chain:    common.BitcoinCash,
+			want:     "qzsvzzkwt9tjl4lv5c4zwks2nse50gqq6scda6xp00",
+			inputKey: testECDSAPublicKey,
+			isEdDSA:  false,
 		},
 		{
-			name:  "Bitcoin",
-			chain: common.Bitcoin,
-			want:  "bc1qxpeg8k8xrygj9ae8q6pkzj29sf7w8e7krm4v5f",
+			name:     "Bitcoin",
+			chain:    common.Bitcoin,
+			want:     "bc1qxpeg8k8xrygj9ae8q6pkzj29sf7w8e7krm4v5f",
+			inputKey: testECDSAPublicKey,
+			isEdDSA:  false,
+		},
+		{
+			name:     "Sui",
+			chain:    common.Sui,
+			want:     "0x7a4629f9194d10526e80d76be734535bd5581ef37760d6914052d26066a8ff7b",
+			inputKey: testEdDSAPublicKey,
+			isEdDSA:  true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetAddress(testECDSAPublicKey, testHexChainCode, tt.chain)
+			got, gotPublicKey, gotIsEdDSA, err := GetAddress(tt.inputKey, testHexChainCode, tt.chain)
 			if err != nil {
 				t.Error(err)
 				t.FailNow()
 			}
 			assert.Equal(t, tt.want, got)
+			// We don't support deriving the public key for EdDSA chains
+			if !tt.isEdDSA {
+				expectedPublicKey, err := tss.GetDerivedPubKey(tt.inputKey, testHexChainCode, tt.chain.GetDerivePath(), tt.chain.IsEdDSA())
+				if err != nil {
+					t.Error(err)
+					t.FailNow()
+				}
+				assert.Equal(t, expectedPublicKey, gotPublicKey)
+			}
+			assert.Equal(t, tt.isEdDSA, gotIsEdDSA)
 		})
 	}
 }


### PR DESCRIPTION
Resolves #21 

This fixes two gaps:

1. It returns the derived public key for ecdsa chains, along with a bool flag indicating the curve type
2. It only attempts to derive subkeys for ecdsa chains - for EdDSA it uses the root key - previously, address.GetAddress would fail when called for EdDSA chains. This fixes that and adds a test case to cover regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved address generation to include the public key and EdDSA status along with the address.
- **Tests**
  - Expanded tests to cover address and public key generation for standard and EdDSA keys, adding new cases for the Sui chain and validation of error handling for invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->