### PR TITLE
policy: remove DerivePath as top level field

### DIFF
--- a/internal/api/policy.go
+++ b/internal/api/policy.go
@@ -65,7 +65,7 @@ func (s *Server) verifyPolicySignature(policy types.PluginPolicy, update bool) b
 		return false
 	}
 
-	isVerified, err := sigutil.VerifySignature(policy.PublicKey, policy.ChainCodeHex, policy.DerivePath, msgBytes, signatureBytes)
+	isVerified, err := sigutil.VerifySignature(policy.PublicKey, policy.ChainCodeHex, msgBytes, signatureBytes)
 	if err != nil {
 		s.logger.Errorf("failed to verify signature: %s", err)
 		return false

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -464,7 +464,6 @@ func (s *Server) Auth(c echo.Context) error {
 
 	success, err := sigutil.VerifySignature(req.PublicKey,
 		req.ChainCodeHex,
-		req.DerivePath,
 		msgBytes,
 		sigBytes)
 	if err != nil {

--- a/internal/sigutil/signing.go
+++ b/internal/sigutil/signing.go
@@ -9,7 +9,7 @@ import (
 
 // VerifySignature verifies a signature against a message using a derived public key
 // This is a placeholder that would be implemented with actual TSS library integration
-func VerifySignature(vaultPublicKey string, chainCodeHex string, derivePath string, messageHex []byte, signature []byte) (bool, error) {
+func VerifySignature(vaultPublicKey string, chainCodeHex string, messageHex []byte, signature []byte) (bool, error) {
 	// In a real implementation, this would:
 	// 1. Derive the public key using TSS library's GetDerivedPubKey function
 	// 2. Parse the public key

--- a/internal/storage/postgres/migrations/20250505163321_remove_derive_path_from_policy.sql
+++ b/internal/storage/postgres/migrations/20250505163321_remove_derive_path_from_policy.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE plugin_policies DROP COLUMN derive_path;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE plugin_policies ADD COLUMN derive_path TEXT NOT NULL;
+-- +goose StatementEnd

--- a/internal/storage/postgres/policy.go
+++ b/internal/storage/postgres/policy.go
@@ -22,7 +22,7 @@ func (p *PostgresBackend) GetPluginPolicy(ctx context.Context, id uuid.UUID) (ty
 	var policyJSON []byte
 
 	query := `
-        SELECT id, public_key, is_ecdsa, chain_code_hex, derive_path, plugin_id, plugin_version, policy_version, plugin_type, signature, active, policy 
+        SELECT id, public_key, is_ecdsa, chain_code_hex, plugin_id, plugin_version, policy_version, plugin_type, signature, active, policy 
         FROM plugin_policies 
         WHERE id = $1`
 
@@ -31,7 +31,6 @@ func (p *PostgresBackend) GetPluginPolicy(ctx context.Context, id uuid.UUID) (ty
 		&policy.PublicKey,
 		&policy.IsEcdsa,
 		&policy.ChainCodeHex,
-		&policy.DerivePath,
 		&policy.PluginID,
 		&policy.PluginVersion,
 		&policy.PolicyVersion,
@@ -55,7 +54,7 @@ func (p *PostgresBackend) GetAllPluginPolicies(ctx context.Context, publicKey st
 	}
 
 	query := `
-  	SELECT id, public_key, is_ecdsa, chain_code_hex, derive_path, plugin_id, plugin_version, policy_version, plugin_type, signature, active, policy 
+  	SELECT id, public_key, is_ecdsa, chain_code_hex, plugin_id, plugin_version, policy_version, plugin_type, signature, active, policy 
 		FROM plugin_policies
 		WHERE public_key = $1
 		AND plugin_type = $2`
@@ -73,7 +72,6 @@ func (p *PostgresBackend) GetAllPluginPolicies(ctx context.Context, publicKey st
 			&policy.PublicKey,
 			&policy.IsEcdsa,
 			&policy.ChainCodeHex,
-			&policy.DerivePath,
 			&policy.PluginID,
 			&policy.PluginVersion,
 			&policy.PolicyVersion,
@@ -99,9 +97,9 @@ func (p *PostgresBackend) InsertPluginPolicyTx(ctx context.Context, dbTx pgx.Tx,
 
 	query := `
   	INSERT INTO plugin_policies (
-      id, public_key, is_ecdsa, chain_code_hex, derive_path, plugin_id, plugin_version, policy_version, plugin_type, signature, active, policy
-    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
-    RETURNING id, public_key, is_ecdsa, chain_code_hex, derive_path, plugin_id, plugin_version, policy_version, plugin_type, signature, active, policy
+      id, public_key, is_ecdsa, chain_code_hex, plugin_id, plugin_version, policy_version, plugin_type, signature, active, policy
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+    RETURNING id, public_key, is_ecdsa, chain_code_hex, plugin_id, plugin_version, policy_version, plugin_type, signature, active, policy
 	`
 
 	var insertedPolicy types.PluginPolicy
@@ -110,7 +108,6 @@ func (p *PostgresBackend) InsertPluginPolicyTx(ctx context.Context, dbTx pgx.Tx,
 		policy.PublicKey,
 		policy.IsEcdsa,
 		policy.ChainCodeHex,
-		policy.DerivePath,
 		policy.PluginID,
 		policy.PluginVersion,
 		policy.PolicyVersion,
@@ -123,7 +120,6 @@ func (p *PostgresBackend) InsertPluginPolicyTx(ctx context.Context, dbTx pgx.Tx,
 		&insertedPolicy.PublicKey,
 		&insertedPolicy.IsEcdsa,
 		&insertedPolicy.ChainCodeHex,
-		&insertedPolicy.DerivePath,
 		&insertedPolicy.PluginID,
 		&insertedPolicy.PluginVersion,
 		&insertedPolicy.PolicyVersion,

--- a/types/policy.go
+++ b/types/policy.go
@@ -11,7 +11,6 @@ type PluginPolicy struct {
 	PublicKey     string          `json:"public_key" validate:"required"`
 	IsEcdsa       bool            `json:"is_ecdsa" validate:"required"`
 	ChainCodeHex  string          `json:"chain_code_hex" validate:"required"`
-	DerivePath    string          `json:"derive_path" validate:"required"`
 	PluginID      string          `json:"plugin_id" validate:"required"`
 	PluginVersion string          `json:"plugin_version" validate:"required"`
 	PolicyVersion string          `json:"policy_version" validate:"required"`


### PR DESCRIPTION
Fixed #20

This is the verifier follow up to https://github.com/vultisig/plugin/pull/32 - we remove DerivePath from the top-level policy document as each individual action inside a policy should be defining its own derivation path (whether explicitly or implicitly - this is for a subsequent PR)

This also removes the corresponding column from the database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the use of the derive path parameter from signature verification and related internal logic.
  - Updated the PluginPolicy structure to no longer include the derive path field.

- **Chores**
  - Migrated the database schema to remove the derive path column from plugin policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->