### PR TITLE
Add JWT-based Vault Authentication and Token Management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,10 @@ cmd/verifier
 cmd/worker
 
 .devenv/
-.DS_Store
-config.json
+
+bin/*
+docker-compose.yaml
+scripts/setup-local.sh
+user_auth.md
+START.md
+localconfig-verifier.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -31,10 +31,5 @@ cmd/verifier
 cmd/worker
 
 .devenv/
-
-bin/*
-docker-compose.yaml
-scripts/setup-local.sh
-user_auth.md
-START.md
-localconfig-verifier.yaml
+.DS_Store
+config.json

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestConfig(t *testing.T) {
-	t.SkipNow()
+	t.Skip("Skipping config test")
 	cfg := Config{}
 	cfg.VaultServiceConfig.Relay.Server = "http://localhost:8080"
 	cfg.VaultServiceConfig.QueueEmailTask = false

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/go-playground/validator/v10 v10.26.0
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/uuid v1.6.0
+	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/hibiken/asynq v0.25.1
 	github.com/jackc/pgx/v5 v5.7.4
 	github.com/labstack/echo/v4 v4.13.3
@@ -35,6 +36,7 @@ require (
 	github.com/vultisig/vultiserver v0.0.0-20250421043311-443d711d503d
 	golang.org/x/crypto v0.36.0
 	google.golang.org/protobuf v1.36.6
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -97,7 +99,6 @@ require (
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-metrics v0.5.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/holiman/uint256 v1.3.2 // indirect
 	github.com/iancoleman/strcase v0.3.0 // indirect
@@ -143,6 +144,7 @@ require (
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect
 	github.com/tendermint/go-amino v0.16.0 // indirect
@@ -163,7 +165,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/blake3 v1.2.1 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -335,9 +335,8 @@ github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
-github.com/hashicorp/go-hclog v1.5.0 h1:bI2ocEMgcVlz55Oj1xZNBsVi900c7II+fWDyV9o+13c=
-github.com/hashicorp/go-hclog v1.5.0/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-hclog v1.6.3 h1:Qr2kF+eVWjTiYmU7Y31tYlP1h0q/X3Nl3tPGdaB11/k=
+github.com/hashicorp/go-hclog v1.6.3/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -27,7 +27,7 @@ func (s *Server) userAuthMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		authHeader := c.Request().Header.Get("Authorization")
 		if authHeader == "" {
-			return c.JSON(http.StatusUnauthorized, echo.Map{"error": "Missing token"})
+			return c.JSON(http.StatusUnauthorized, NewErrorResponse("Authorization header required"))
 		}
 
 		// TODO: add user authentication logic
@@ -40,14 +40,14 @@ func (s *Server) AuthMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		authHeader := c.Request().Header.Get("Authorization")
 		if authHeader == "" {
-			return c.JSON(http.StatusUnauthorized, map[string]string{"error": "Missing Authorization header"})
+			return c.JSON(http.StatusUnauthorized, NewErrorResponse("Authorization header required"))
 		}
 
 		tokenStr := authHeader[len("Bearer "):]
 		_, err := s.authService.ValidateToken(tokenStr)
 		if err != nil {
 			s.logger.Warnf("fail to validate token, err: %v", err)
-			return c.JSON(http.StatusUnauthorized, map[string]string{"error": "Unauthorized"})
+			return c.JSON(http.StatusUnauthorized, NewErrorResponse("Unauthorized"))
 		}
 		s.logger.Info("Token validated successfully")
 		return next(c)

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -45,7 +45,7 @@ func (s *Server) AuthMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 		}
 
 		tokenStr := authHeader[len("Bearer "):]
-		_, err := s.authService.ValidateToken(tokenStr)
+		_, err := s.authService.ValidateToken(c.Request().Context(), tokenStr)
 		if err != nil {
 			s.logger.Warnf("fail to validate token, err: %v", err)
 			return c.JSON(http.StatusUnauthorized, NewErrorResponse("Unauthorized"))
@@ -71,7 +71,7 @@ func (s *Server) VaultAuthMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 		}
 
 		// Validate token and get claims
-		claims, err := s.authService.ValidateToken(tokenParts[1])
+		claims, err := s.authService.ValidateToken(c.Request().Context(), tokenParts[1])
 		if err != nil {
 			s.logger.Errorf("Internal error: %v", err)
 			return c.JSON(http.StatusInternalServerError, NewErrorResponse("An internal error occurred"))

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -50,6 +51,57 @@ func (s *Server) AuthMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 			return c.JSON(http.StatusUnauthorized, NewErrorResponse("Unauthorized"))
 		}
 		s.logger.Info("Token validated successfully")
+		return next(c)
+	}
+}
+
+// VaultAuthMiddleware verifies JWT tokens and ensures users can only access their own vaults
+func (s *Server) VaultAuthMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		// Get token from header
+		authHeader := c.Request().Header.Get("Authorization")
+		if authHeader == "" {
+			return c.JSON(http.StatusUnauthorized, map[string]string{
+				"error": "Missing authorization header",
+			})
+		}
+
+		// Extract token from Bearer format
+		tokenParts := strings.Split(authHeader, " ")
+		if len(tokenParts) != 2 || tokenParts[0] != "Bearer" {
+			return c.JSON(http.StatusUnauthorized, map[string]string{
+				"error": "Invalid authorization header format",
+			})
+		}
+
+		// Validate token and get claims
+		claims, err := s.authService.ValidateToken(tokenParts[1])
+		if err != nil {
+			return c.JSON(http.StatusUnauthorized, map[string]string{
+				"error": "Invalid or expired token: " + err.Error(),
+			})
+		}
+
+		// Get requested vault's public key from URL parameter
+		requestedPublicKey := c.Param("publicKeyECDSA")
+		if requestedPublicKey == "" {
+			return c.JSON(http.StatusBadRequest, map[string]string{
+				"error": "Missing vault public key",
+			})
+		}
+
+		// Verify the token's public key matches the requested vault
+		if claims.PublicKey != requestedPublicKey {
+			s.logger.Warnf("Access denied: token public key %s does not match requested vault %s",
+				claims.PublicKey, requestedPublicKey)
+			return c.JSON(http.StatusForbidden, map[string]string{
+				"error": "Access denied: token not authorized for this vault",
+			})
+		}
+
+		// Store the public key in context for later use
+		c.Set("vault_public_key", claims.PublicKey)
+
 		return next(c)
 	}
 }

--- a/internal/api/plugin.go
+++ b/internal/api/plugin.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+
+	"github.com/vultisig/verifier/internal/types"
+)
+
+func (s *Server) GetPlugins(c echo.Context) error {
+	skip, err := strconv.Atoi(c.QueryParam("skip"))
+
+	if err != nil {
+		skip = 0
+	}
+
+	take, err := strconv.Atoi(c.QueryParam("take"))
+
+	if err != nil {
+		take = 999
+	}
+
+	sort := c.QueryParam("sort")
+
+	plugins, err := s.db.FindPlugins(c.Request().Context(), skip, take, sort)
+	if err != nil {
+		s.logger.WithError(err).Error("Failed to get plugins")
+		return c.JSON(http.StatusInternalServerError, NewErrorResponse("failed to get plugins"))
+	}
+
+	return c.JSON(http.StatusOK, plugins)
+}
+
+func (s *Server) GetPlugin(c echo.Context) error {
+	pluginID := c.Param("pluginId")
+	if pluginID == "" {
+		return c.JSON(http.StatusBadRequest, NewErrorResponse("failed to get plugin"))
+	}
+	uPluginID, err := uuid.Parse(pluginID)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, NewErrorResponse("failed to get plugin"))
+	}
+	plugin, err := s.db.FindPluginById(c.Request().Context(), uPluginID)
+	if err != nil {
+		s.logger.WithError(err).Error("Failed to get plugin")
+		return c.JSON(http.StatusInternalServerError, NewErrorResponse("failed to get plugin"))
+	}
+
+	return c.JSON(http.StatusOK, plugin)
+}
+
+func (s *Server) CreatePlugin(c echo.Context) error {
+	var plugin types.PluginCreateDto
+	if err := c.Bind(&plugin); err != nil {
+		return c.JSON(http.StatusBadRequest, NewErrorResponse("invalid request"))
+	}
+
+	if err := c.Validate(&plugin); err != nil {
+		return c.JSON(http.StatusBadRequest, NewErrorResponse(err.Error()))
+	}
+
+	created, err := s.db.CreatePlugin(c.Request().Context(), plugin)
+	if err != nil {
+		s.logger.WithError(err).Error("Failed to create plugin")
+		return c.JSON(http.StatusInternalServerError, NewErrorResponse("failed to create plugin"))
+	}
+
+	return c.JSON(http.StatusOK, created)
+}
+
+func (s *Server) UpdatePlugin(c echo.Context) error {
+	pluginID := c.Param("pluginId")
+	if pluginID == "" {
+		return c.JSON(http.StatusBadRequest, NewErrorResponse("plugin id is required"))
+	}
+
+	var plugin types.PluginUpdateDto
+	if err := c.Bind(&plugin); err != nil {
+		return c.JSON(http.StatusBadRequest, NewErrorResponse("invalid request"))
+	}
+
+	if err := c.Validate(&plugin); err != nil {
+		return c.JSON(http.StatusBadRequest, NewErrorResponse(err.Error()))
+	}
+	uPluginID, err := uuid.Parse(pluginID)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, NewErrorResponse("invalid plugin id"))
+	}
+	updated, err := s.db.UpdatePlugin(c.Request().Context(), uPluginID, plugin)
+	if err != nil {
+		s.logger.WithError(err).Error("Failed to update plugin")
+		return c.JSON(http.StatusInternalServerError, NewErrorResponse("failed to update plugin"))
+	}
+
+	return c.JSON(http.StatusOK, updated)
+}
+
+func (s *Server) DeletePlugin(c echo.Context) error {
+	pluginID := c.Param("pluginId")
+	if pluginID == "" {
+		return c.JSON(http.StatusBadRequest, NewErrorResponse("plugin id is required"))
+	}
+	uPluginID, err := uuid.Parse(pluginID)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, NewErrorResponse("invalid plugin id"))
+	}
+	if err := s.db.DeletePluginById(c.Request().Context(), uPluginID); err != nil {
+		s.logger.WithError(err).Error("Failed to delete plugin")
+		return c.JSON(http.StatusInternalServerError, NewErrorResponse("failed to delete plugin"))
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}

--- a/internal/api/plugin.go
+++ b/internal/api/plugin.go
@@ -25,7 +25,7 @@ func (s *Server) GetPlugins(c echo.Context) error {
 
 	sort := c.QueryParam("sort")
 
-	plugins, err := s.db.FindPlugins(c.Request().Context(), skip, take, sort)
+	plugins, err := s.db.FindPlugins(c.Request().Context(), take, skip, sort)
 	if err != nil {
 		s.logger.WithError(err).Error("Failed to get plugins")
 		return c.JSON(http.StatusInternalServerError, NewErrorResponse("failed to get plugins"))

--- a/internal/api/policy.go
+++ b/internal/api/policy.go
@@ -65,7 +65,8 @@ func (s *Server) verifyPolicySignature(policy types.PluginPolicy, update bool) b
 		return false
 	}
 
-	isVerified, err := sigutil.VerifySignature(policy.PublicKey, policy.ChainCodeHex, msgBytes, signatureBytes)
+	// TODO: We might use ETH key to sign the policy, thus let's get the ETH public key
+	isVerified, err := sigutil.VerifySignature(policy.PublicKey, msgBytes, signatureBytes)
 	if err != nil {
 		s.logger.Errorf("failed to verify signature: %s", err)
 		return false

--- a/internal/api/pricing.go
+++ b/internal/api/pricing.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 
 	"github.com/vultisig/verifier/internal/types"
@@ -14,8 +15,11 @@ func (s *Server) GetPricing(c echo.Context) error {
 	if pricingID == "" {
 		return c.JSON(http.StatusBadRequest, NewErrorResponse("invalid pricing id"))
 	}
-
-	pricing, err := s.db.FindPricingById(c.Request().Context(), pricingID)
+	uPricingID, err := uuid.Parse(pricingID)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, NewErrorResponse("invalid pricing id"))
+	}
+	pricing, err := s.db.FindPricingById(c.Request().Context(), uPricingID)
 	if err != nil {
 		s.logger.Errorf("error finding pricing %s: %v", pricingID, err)
 		return c.JSON(http.StatusInternalServerError, NewErrorResponse("failed to get pricing"))
@@ -49,9 +53,11 @@ func (s *Server) DeletePricing(c echo.Context) error {
 	if pricingID == "" {
 		return c.JSON(http.StatusBadRequest, NewErrorResponse("invalid pricing id"))
 	}
-
-	err := s.db.DeletePricingById(c.Request().Context(), pricingID)
+	uPricingID, err := uuid.Parse(pricingID)
 	if err != nil {
+		return c.JSON(http.StatusBadRequest, NewErrorResponse("invalid pricing id"))
+	}
+	if err := s.db.DeletePricingById(c.Request().Context(), uPricingID); err != nil {
 		s.logger.Errorf("error deleting pricing %s: %s", pricingID, err)
 		return c.JSON(http.StatusInternalServerError, NewErrorResponse("failed to delete pricing"))
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -64,7 +64,7 @@ func NewServer(
 		logrus.Fatalf("Failed to initialize policy service: %v", err)
 	}
 
-	authService := service.NewAuthService(jwtSecret, db)
+	authService := service.NewAuthService(jwtSecret, db, logrus.WithField("service", "auth-service").Logger)
 
 	return &Server{
 		cfg:           cfg,

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -499,7 +499,7 @@ func (s *Server) Auth(c echo.Context) error {
 	}
 
 	// Store logged-in user's public key in cache for quick access
-	cacheKey := "user_pubkey:" + token[0:10]                                          // Use first part of token as a cache key
+	cacheKey := "user_pubkey:" + token
 	err = s.redis.Set(c.Request().Context(), cacheKey, req.PublicKey, 7*24*time.Hour) // Same as token expiration
 	if err != nil {
 		s.logger.Warnf("Failed to cache user info: %v", err)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -29,6 +29,7 @@ import (
 	"github.com/labstack/gommon/log"
 	"github.com/sirupsen/logrus"
 	"github.com/vultisig/mobile-tss-lib/tss"
+	"github.com/vultisig/verifier/internal/clientutil"
 )
 
 type Server struct {
@@ -96,7 +97,7 @@ func (s *Server) StartServer() error {
 	e.GET("/ping", s.Ping)
 	e.GET("/getDerivedPublicKey", s.GetDerivedPublicKey)
 
-	// Auth token
+	// Auth endpoints - not requiring authentication
 	e.POST("/auth", s.Auth)
 	e.POST("/auth/refresh", s.RefreshToken)
 
@@ -437,43 +438,67 @@ func (s *Server) Auth(c echo.Context) error {
 	var req struct {
 		Message      string `json:"message"`
 		Signature    string `json:"signature"`
-		DerivePath   string `json:"derive_path"`
 		ChainCodeHex string `json:"chain_code_hex"`
 		PublicKey    string `json:"public_key"`
 	}
 
 	if err := c.Bind(&req); err != nil {
-		return c.NoContent(http.StatusBadRequest)
+		return c.JSON(http.StatusBadRequest, NewErrorResponse("Invalid request format"))
 	}
 
-	msgBytes, err := hex.DecodeString(strings.TrimPrefix(req.Message, "0x"))
+	// Validate required fields
+	if err := clientutil.ValidateAuthRequest(
+		req.Message, req.Signature, req.PublicKey, req.ChainCodeHex,
+	); err != nil {
+		return c.JSON(http.StatusBadRequest, NewErrorResponse(err.Error()))
+	}
+
+	// Verify the message format matches the expected format from client
+	expectedMessage := clientutil.GenerateHexMessage(req.PublicKey)
+	if req.Message != expectedMessage {
+		s.logger.Warnf("Message mismatch: expected %s, got %s", expectedMessage, req.Message)
+		// Allow some flexibility in message format by continuing anyway
+	}
+
+	// Decode message from hex (remove 0x prefix first)
+	msgWithoutPrefix := strings.TrimPrefix(req.Message, "0x")
+	msgBytes, err := hex.DecodeString(msgWithoutPrefix)
 	if err != nil {
 		s.logger.Errorf("failed to decode message: %v", err)
-		return c.NoContent(http.StatusBadRequest)
+		return c.JSON(http.StatusBadRequest, NewErrorResponse("Invalid message format"))
 	}
 
-	sigBytes, err := hex.DecodeString(strings.TrimPrefix(req.Signature, "0x"))
+	// Decode signature from hex (remove 0x prefix first)
+	sigWithoutPrefix := strings.TrimPrefix(req.Signature, "0x")
+	sigBytes, err := hex.DecodeString(sigWithoutPrefix)
 	if err != nil {
 		s.logger.Errorf("failed to decode signature: %v", err)
-		return c.NoContent(http.StatusBadRequest)
+		return c.JSON(http.StatusBadRequest, NewErrorResponse("Invalid signature format"))
 	}
 
-	success, err := sigutil.VerifySignature(req.PublicKey,
-		req.ChainCodeHex,
-		msgBytes,
-		sigBytes)
+	// Verify the signature using our utility
+	success, err := sigutil.VerifySignature(req.PublicKey, req.ChainCodeHex, msgBytes, sigBytes)
 	if err != nil {
 		s.logger.Errorf("signature verification failed: %v", err)
-		return c.NoContent(http.StatusUnauthorized)
+		return c.JSON(http.StatusUnauthorized, NewErrorResponse("Signature verification failed: "+err.Error()))
 	}
 	if !success {
-		return c.NoContent(http.StatusUnauthorized)
+		return c.JSON(http.StatusUnauthorized, NewErrorResponse("Invalid signature"))
 	}
 
+	// Generate JWT token with the public key
 	token, err := s.authService.GenerateToken()
 	if err != nil {
 		s.logger.Error("failed to generate token:", err)
-		return c.NoContent(http.StatusInternalServerError)
+		return c.JSON(http.StatusInternalServerError, NewErrorResponse("Failed to generate auth token"))
+	}
+
+	// Store logged-in user's public key in cache for quick access
+	cacheKey := "user_pubkey:" + token[0:10]                                          // Use first part of token as a cache key
+	err = s.redis.Set(c.Request().Context(), cacheKey, req.PublicKey, 7*24*time.Hour) // Same as token expiration
+	if err != nil {
+		s.logger.Warnf("Failed to cache user info: %v", err)
+		// Continue anyway since this is not critical
 	}
 
 	return c.JSON(http.StatusOK, map[string]string{"token": token})
@@ -486,13 +511,17 @@ func (s *Server) RefreshToken(c echo.Context) error {
 
 	if err := c.Bind(&req); err != nil {
 		s.logger.Errorf("fail to decode token, err: %v", err)
-		return c.NoContent(http.StatusBadRequest)
+		return c.JSON(http.StatusBadRequest, NewErrorResponse("Invalid request format"))
+	}
+
+	if req.Token == "" {
+		return c.JSON(http.StatusBadRequest, NewErrorResponse("Missing token"))
 	}
 
 	newToken, err := s.authService.RefreshToken(req.Token)
 	if err != nil {
 		s.logger.Errorf("fail to refresh token, err: %v", err)
-		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "Invalid or expired token"})
+		return c.JSON(http.StatusUnauthorized, NewErrorResponse("Invalid or expired token"))
 	}
 
 	return c.JSON(http.StatusOK, map[string]string{"token": newToken})

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -63,7 +63,7 @@ func NewServer(
 		logrus.Fatalf("Failed to initialize policy service: %v", err)
 	}
 
-	authService := service.NewAuthService(jwtSecret)
+	authService := service.NewAuthService(jwtSecret, db)
 
 	return &Server{
 		cfg:           cfg,
@@ -101,14 +101,22 @@ func (s *Server) StartServer() error {
 	e.POST("/auth", s.Auth)
 	e.POST("/auth/refresh", s.RefreshToken)
 
-	grp := e.Group("/vault")
-	grp.POST("/create", s.CreateVault)
-	grp.POST("/reshare", s.ReshareVault)
-	grp.GET("/get/:publicKeyECDSA", s.GetVault)     // Get Vault Data
-	grp.GET("/exist/:publicKeyECDSA", s.ExistVault) // Check if Vault exists
+	// Token management endpoints
+	tokenGroup := e.Group("/auth/tokens")
+	tokenGroup.Use(s.VaultAuthMiddleware)
+	tokenGroup.DELETE("/:tokenId", s.RevokeToken)
+	tokenGroup.DELETE("/all", s.RevokeAllTokens)
+	tokenGroup.GET("", s.GetActiveTokens)
 
-	grp.POST("/sign", s.SignMessages)                     // Sign messages
-	grp.GET("/sign/response/:taskId", s.GetKeysignResult) // Get keysign result
+	// Protected vault endpoints
+	vaultGroup := e.Group("/vault")
+	vaultGroup.Use(s.VaultAuthMiddleware) // Apply vault auth middleware to all vault endpoints
+	vaultGroup.POST("/create", s.CreateVault)
+	vaultGroup.POST("/reshare", s.ReshareVault)
+	vaultGroup.GET("/get/:publicKeyECDSA", s.GetVault)           // Get Vault Data
+	vaultGroup.GET("/exist/:publicKeyECDSA", s.ExistVault)       // Check if Vault exists
+	vaultGroup.POST("/sign", s.SignMessages)                     // Sign messages
+	vaultGroup.GET("/sign/response/:taskId", s.GetKeysignResult) // Get keysign result
 
 	pluginGroup := e.Group("/plugin", s.userAuthMiddleware)
 	pluginGroup.POST("/policy", s.CreatePluginPolicy)
@@ -483,7 +491,7 @@ func (s *Server) Auth(c echo.Context) error {
 	}
 
 	// Generate JWT token with the public key
-	token, err := s.authService.GenerateToken()
+	token, err := s.authService.GenerateToken(req.PublicKey)
 	if err != nil {
 		s.logger.Error("failed to generate token:", err)
 		return c.JSON(http.StatusInternalServerError, NewErrorResponse("Failed to generate auth token"))
@@ -521,4 +529,66 @@ func (s *Server) RefreshToken(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, map[string]string{"token": newToken})
+}
+
+// RevokeToken revokes a specific token
+func (s *Server) RevokeToken(c echo.Context) error {
+	tokenID := c.Param("tokenId")
+	if tokenID == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{
+			"error": "Missing token ID",
+		})
+	}
+
+	err := s.authService.RevokeToken(tokenID)
+	if err != nil {
+		s.logger.Errorf("Failed to revoke token: %v", err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{
+			"error": "Failed to revoke token",
+		})
+	}
+
+	return c.NoContent(http.StatusOK)
+}
+
+// RevokeAllTokens revokes all tokens for the authenticated vault
+func (s *Server) RevokeAllTokens(c echo.Context) error {
+	// Get public key from context (set by VaultAuthMiddleware)
+	publicKey, ok := c.Get("vault_public_key").(string)
+	if !ok {
+		return c.JSON(http.StatusInternalServerError, map[string]string{
+			"error": "Failed to get vault public key",
+		})
+	}
+
+	err := s.authService.RevokeAllTokens(publicKey)
+	if err != nil {
+		s.logger.Errorf("Failed to revoke all tokens: %v", err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{
+			"error": "Failed to revoke all tokens",
+		})
+	}
+
+	return c.NoContent(http.StatusOK)
+}
+
+// GetActiveTokens returns all active tokens for the authenticated vault
+func (s *Server) GetActiveTokens(c echo.Context) error {
+	// Get public key from context (set by VaultAuthMiddleware)
+	publicKey, ok := c.Get("vault_public_key").(string)
+	if !ok {
+		return c.JSON(http.StatusInternalServerError, map[string]string{
+			"error": "Failed to get vault public key",
+		})
+	}
+
+	tokens, err := s.authService.GetActiveTokens(publicKey)
+	if err != nil {
+		s.logger.Errorf("Failed to get active tokens: %v", err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{
+			"error": "Failed to get active tokens",
+		})
+	}
+
+	return c.JSON(http.StatusOK, tokens)
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -492,7 +492,7 @@ func (s *Server) Auth(c echo.Context) error {
 	}
 
 	// Generate JWT token with the public key
-	token, err := s.authService.GenerateToken(req.PublicKey)
+	token, err := s.authService.GenerateToken(c.Request().Context(), req.PublicKey)
 	if err != nil {
 		s.logger.Error("failed to generate token:", err)
 		return c.JSON(http.StatusInternalServerError, NewErrorResponse("Failed to generate auth token"))
@@ -523,7 +523,7 @@ func (s *Server) RefreshToken(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, NewErrorResponse("Missing token"))
 	}
 
-	newToken, err := s.authService.RefreshToken(req.Token)
+	newToken, err := s.authService.RefreshToken(c.Request().Context(), req.Token)
 	if err != nil {
 		s.logger.Errorf("fail to refresh token, err: %v", err)
 		return c.JSON(http.StatusUnauthorized, NewErrorResponse("Invalid or expired token"))
@@ -576,7 +576,7 @@ func (s *Server) RevokeAllTokens(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, NewErrorResponse("Failed to get vault public key"))
 	}
 
-	err := s.authService.RevokeAllTokens(publicKey)
+	err := s.authService.RevokeAllTokens(c.Request().Context(), publicKey)
 	if err != nil {
 		s.logger.Errorf("Failed to revoke all tokens: %v", err)
 		return c.JSON(http.StatusInternalServerError, NewErrorResponse("Failed to revoke all tokens"))
@@ -593,7 +593,7 @@ func (s *Server) GetActiveTokens(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, NewErrorResponse("Failed to get vault public key"))
 	}
 
-	tokens, err := s.authService.GetActiveTokens(publicKey)
+	tokens, err := s.authService.GetActiveTokens(c.Request().Context(), publicKey)
 	if err != nil {
 		s.logger.Errorf("Failed to get active tokens: %v", err)
 		return c.JSON(http.StatusInternalServerError, NewErrorResponse("Failed to get active tokens"))

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -473,7 +473,7 @@ func (s *Server) Auth(c echo.Context) error {
 	}
 
 	// Verify the signature using our utility
-	success, err := sigutil.VerifySignature(req.PublicKey, req.ChainCodeHex, msgBytes, sigBytes)
+	success, err := sigutil.VerifySignature(req.PublicKey, msgBytes, sigBytes)
 	if err != nil {
 		s.logger.Errorf("signature verification failed: %v", err)
 		return c.JSON(http.StatusUnauthorized, NewErrorResponse("Signature verification failed: "+err.Error()))

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -9,8 +9,18 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-go/statsd"
+	"github.com/go-playground/validator/v10"
+	"github.com/hibiken/asynq"
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+	"github.com/labstack/gommon/log"
+	"github.com/sirupsen/logrus"
+	"github.com/vultisig/mobile-tss-lib/tss"
+
 	"github.com/vultisig/verifier/common"
 	"github.com/vultisig/verifier/config"
+	"github.com/vultisig/verifier/internal/clientutil"
 	"github.com/vultisig/verifier/internal/service"
 	"github.com/vultisig/verifier/internal/sigutil"
 	"github.com/vultisig/verifier/internal/storage"
@@ -20,16 +30,6 @@ import (
 	vv "github.com/vultisig/verifier/internal/vultisig_validator"
 	types2 "github.com/vultisig/verifier/types"
 	"github.com/vultisig/verifier/vault"
-
-	"github.com/DataDog/datadog-go/statsd"
-	"github.com/go-playground/validator/v10"
-	"github.com/hibiken/asynq"
-	"github.com/labstack/echo/v4"
-	"github.com/labstack/echo/v4/middleware"
-	"github.com/labstack/gommon/log"
-	"github.com/sirupsen/logrus"
-	"github.com/vultisig/mobile-tss-lib/tss"
-	"github.com/vultisig/verifier/internal/clientutil"
 )
 
 type Server struct {
@@ -117,23 +117,19 @@ func (s *Server) StartServer() error {
 	pluginGroup.GET("/policy/:policyId", s.GetPluginPolicyById)
 	pluginGroup.DELETE("/policy/:policyId", s.DeletePluginPolicyById)
 
-	// if s.mode == "verifier" {
-	// 	e.POST("/login", s.UserLogin)
-	// 	e.GET("/users/me", s.GetLoggedUser, s.userAuthMiddleware)
-	//
-	// 	pluginsGroup := e.Group("/plugins")
-	// 	pluginsGroup.GET("", s.GetPlugins)
-	// 	pluginsGroup.GET("/:pluginId", s.GetPlugin)
-	// 	pluginsGroup.POST("", s.CreatePlugin, s.userAuthMiddleware)
-	// 	pluginsGroup.PATCH("/:pluginId", s.UpdatePlugin, s.userAuthMiddleware)
-	// 	pluginsGroup.DELETE("/:pluginId", s.DeletePlugin, s.userAuthMiddleware)
-	// }
+	pluginsGroup := e.Group("/plugins")
+	pluginsGroup.GET("", s.GetPlugins)
+	pluginsGroup.GET("/:pluginId", s.GetPlugin)
+	pluginsGroup.POST("", s.CreatePlugin, s.userAuthMiddleware)
+	pluginsGroup.POST("/:pluginId", s.UpdatePlugin, s.userAuthMiddleware)
+	pluginsGroup.DELETE("/:pluginId", s.DeletePlugin, s.userAuthMiddleware)
 
 	pricingsGroup := e.Group("/pricing")
 	pricingsGroup.GET("/:pricingId", s.GetPricing)
 	pricingsGroup.POST("", s.CreatePricing, s.userAuthMiddleware)
 	pricingsGroup.DELETE("/:pricingId", s.DeletePricing, s.userAuthMiddleware)
 	syncGroup := e.Group("/sync", s.userAuthMiddleware)
+
 	syncGroup.POST("/transaction", s.CreateTransaction)
 	syncGroup.PUT("/transaction", s.UpdateTransaction)
 

--- a/internal/clientutil/auth_utils.go
+++ b/internal/clientutil/auth_utils.go
@@ -72,20 +72,6 @@ func FormatAuthResponse(token string, err error) map[string]interface{} {
 	}
 }
 
-// ExtractBearerToken extracts the token from the Authorization header
-func ExtractBearerToken(authHeader string) (string, error) {
-	if authHeader == "" {
-		return "", fmt.Errorf("missing authorization header")
-	}
-
-	parts := strings.Split(authHeader, " ")
-	if len(parts) != 2 || parts[0] != "Bearer" {
-		return "", fmt.Errorf("invalid authorization format, use: Bearer <token>")
-	}
-
-	return parts[1], nil
-}
-
 // StripHexPrefix removes the 0x prefix from a hex string if present
 func StripHexPrefix(hex string) string {
 	if strings.HasPrefix(hex, "0x") {

--- a/internal/clientutil/auth_utils.go
+++ b/internal/clientutil/auth_utils.go
@@ -1,0 +1,116 @@
+package clientutil
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// GenerateHexMessage creates the same message format that the client uses
+// This ensures that the server can verify signatures using the same message format
+func GenerateHexMessage(publicKey string) string {
+	// Trim 0x prefix if present
+	publicKeyTrimmed := publicKey
+	if strings.HasPrefix(publicKeyTrimmed, "0x") {
+		publicKeyTrimmed = publicKeyTrimmed[2:]
+	}
+
+	// Append "1" to the public key, as done in the client-side implementation
+	messageToSign := publicKeyTrimmed + "1"
+
+	// Convert to hex string with 0x prefix
+	return "0x" + messageToSign
+}
+
+// ToHex converts a string to a hex string (this mimics the client-side toHex function)
+func ToHex(input string) string {
+	bytes := []byte(input)
+	return "0x" + hex.EncodeToString(bytes)
+}
+
+// ValidateAuthRequest checks if an authentication request has all required fields
+func ValidateAuthRequest(message, signature, publicKey, chainCodeHex string) error {
+	if message == "" {
+		return fmt.Errorf("message is required")
+	}
+	if signature == "" {
+		return fmt.Errorf("signature is required")
+	}
+	if publicKey == "" {
+		return fmt.Errorf("public key is required")
+	}
+	if chainCodeHex == "" {
+		return fmt.Errorf("chain code hex is required")
+	}
+
+	// Validate hex formats
+	if !strings.HasPrefix(message, "0x") {
+		return fmt.Errorf("message must be a hex string with 0x prefix")
+	}
+	if !strings.HasPrefix(signature, "0x") {
+		return fmt.Errorf("signature must be a hex string with 0x prefix")
+	}
+	if !strings.HasPrefix(publicKey, "0x") {
+		return fmt.Errorf("public key must be a hex string with 0x prefix")
+	}
+
+	return nil
+}
+
+// FormatAuthResponse formats an authentication response according to the client expectation
+func FormatAuthResponse(token string, err error) map[string]interface{} {
+	if err != nil {
+		return map[string]interface{}{
+			"error": err.Error(),
+		}
+	}
+	return map[string]interface{}{
+		"token": token,
+	}
+}
+
+// ExtractBearerToken extracts the token from the Authorization header
+func ExtractBearerToken(authHeader string) (string, error) {
+	if authHeader == "" {
+		return "", fmt.Errorf("missing authorization header")
+	}
+
+	parts := strings.Split(authHeader, " ")
+	if len(parts) != 2 || parts[0] != "Bearer" {
+		return "", fmt.Errorf("invalid authorization format, use: Bearer <token>")
+	}
+
+	return parts[1], nil
+}
+
+// StripHexPrefix removes the 0x prefix from a hex string if present
+func StripHexPrefix(hex string) string {
+	if strings.HasPrefix(hex, "0x") {
+		return hex[2:]
+	}
+	return hex
+}
+
+// AddHexPrefix adds the 0x prefix to a hex string if not present
+func AddHexPrefix(hex string) string {
+	if !strings.HasPrefix(hex, "0x") {
+		return "0x" + hex
+	}
+	return hex
+}
+
+// GetTimestamp returns the current Unix timestamp in seconds
+func GetTimestamp() int64 {
+	return time.Now().Unix()
+}
+
+// IsValidEthAddress checks if a string is a valid Ethereum address
+func IsValidEthAddress(address string) bool {
+	if !strings.HasPrefix(address, "0x") {
+		return false
+	}
+	return common.IsHexAddress(address)
+}

--- a/internal/clientutil/auth_utils.go
+++ b/internal/clientutil/auth_utils.go
@@ -50,11 +50,11 @@ func ValidateAuthRequest(message, signature, publicKey, chainCodeHex string) err
 	if !strings.HasPrefix(message, "0x") {
 		return fmt.Errorf("message must be a hex string with 0x prefix")
 	}
-	if !strings.HasPrefix(signature, "0x") {
-		return fmt.Errorf("signature must be a hex string with 0x prefix")
+	if !isValidPrefixedHex(signature) {
+		return fmt.Errorf("signature must be a valid 0x-prefixed hex string")
 	}
-	if !strings.HasPrefix(publicKey, "0x") {
-		return fmt.Errorf("public key must be a hex string with 0x prefix")
+	if !isValidPrefixedHex(publicKey) {
+		return fmt.Errorf("public key must be a valid 0x-prefixed hex string")
 	}
 
 	return nil
@@ -113,4 +113,13 @@ func IsValidEthAddress(address string) bool {
 		return false
 	}
 	return common.IsHexAddress(address)
+}
+
+// helper
+func isValidPrefixedHex(v string) bool {
+	if !strings.HasPrefix(v, "0x") {
+		return false
+	}
+	_, err := hex.DecodeString(v[2:])
+	return err == nil
 }

--- a/internal/clientutil/auth_utils_test.go
+++ b/internal/clientutil/auth_utils_test.go
@@ -1,0 +1,48 @@
+package clientutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateHexMessage(t *testing.T) {
+	tests := []struct {
+		name      string
+		publicKey string
+		want      string
+	}{
+		{
+			name:      "Public key with 0x prefix",
+			publicKey: "0x1234567890abcdef",
+			want:      "0x1234567890abcdef1",
+		},
+		{
+			name:      "Public key without 0x prefix",
+			publicKey: "1234567890abcdef",
+			want:      "0x1234567890abcdef1",
+		},
+		{
+			name:      "Empty public key",
+			publicKey: "",
+			want:      "0x1",
+		},
+		{
+			name:      "Short public key",
+			publicKey: "0x123",
+			want:      "0x1231",
+		},
+		{
+			name:      "Very long public key",
+			publicKey: "0x" + "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			want:      "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GenerateHexMessage(tt.publicKey)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -127,12 +127,13 @@ func (a *AuthService) ValidateToken(tokenStr string) (*Claims, error) {
 		return nil, errors.New("token missing token ID")
 	}
 
-	// Check if token is revoked
+	if a.db == nil {
+		return nil, errors.New("database not configured")
+	}
 	dbToken, err := a.db.GetVaultToken(context.Background(), claims.TokenID)
 	if err != nil {
 		return nil, errors.New("token not found in database")
 	}
-
 	if dbToken == nil {
 		return nil, errors.New("token not found in database")
 	}

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -1,49 +1,106 @@
 package service
 
 import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"errors"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/vultisig/verifier/internal/storage"
+	"github.com/vultisig/verifier/internal/types"
 )
 
 type Claims struct {
 	jwt.RegisteredClaims
+	PublicKey string `json:"public_key"`
+	TokenID   string `json:"token_id"`
 }
 
 const (
 	expireDuration = 7 * 24 * time.Hour
+	tokenIDLength  = 32
 )
 
 type AuthService struct {
 	JWTSecret []byte
+	db        storage.DatabaseStorage
 }
 
 // NewAuthService creates a new authentication service
-func NewAuthService(secret string) *AuthService {
+func NewAuthService(secret string, db storage.DatabaseStorage) *AuthService {
 	return &AuthService{
 		JWTSecret: []byte(secret),
+		db:        db,
 	}
 }
 
-// GenerateToken creates a new JWT token
-func (a *AuthService) GenerateToken() (string, error) {
+// generateTokenID generates a random token ID
+func generateTokenID() (string, error) {
+	b := make([]byte, tokenIDLength)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.URLEncoding.EncodeToString(b), nil
+}
+
+// GenerateToken creates a new JWT token and stores it in the database
+func (a *AuthService) GenerateToken(publicKey string) (string, error) {
+	ctx := context.Background()
+
+	// Generate a unique token ID
+	tokenID, err := generateTokenID()
+	if err != nil {
+		return "", err
+	}
+
 	expirationTime := time.Now().Add(expireDuration)
 	claims := &Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(expirationTime),
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
 		},
+		PublicKey: publicKey,
+		TokenID:   tokenID,
 	}
+
+	// Create JWT token
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	return token.SignedString(a.JWTSecret)
+	tokenString, err := token.SignedString(a.JWTSecret)
+	if err != nil {
+		return "", err
+	}
+
+	// Store token in database
+	tx, err := a.db.Pool().Begin(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer tx.Rollback(ctx)
+
+	_, err = a.db.CreateVaultToken(ctx, types.VaultTokenCreate{
+		PublicKey: publicKey,
+		TokenID:   tokenID,
+		ExpiresAt: expirationTime,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return "", err
+	}
+
+	return tokenString, nil
 }
 
-// ValidateToken validates a JWT token and returns the claims
+// ValidateToken validates a JWT token and checks its revocation status
 func (a *AuthService) ValidateToken(tokenStr string) (*Claims, error) {
+	ctx := context.Background()
+
 	claims := &Claims{}
 	token, err := jwt.ParseWithClaims(tokenStr, claims, func(token *jwt.Token) (interface{}, error) {
-		// Validate signing method
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, errors.New("unexpected signing method")
 		}
@@ -56,14 +113,126 @@ func (a *AuthService) ValidateToken(tokenStr string) (*Claims, error) {
 		return nil, errors.New("invalid or expired token")
 	}
 
+	// Validate key fields
+	if claims.PublicKey == "" {
+		return nil, errors.New("token missing public key")
+	}
+	if claims.TokenID == "" {
+		return nil, errors.New("token missing token ID")
+	}
+
+	// Check if token is revoked
+	tx, err := a.db.Pool().Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx)
+
+	dbToken, err := a.db.GetVaultToken(ctx, claims.TokenID)
+	if err != nil {
+		return nil, errors.New("token not found in database")
+	}
+	if dbToken.IsRevoked {
+		return nil, errors.New("token has been revoked")
+	}
+
+	// Update last used timestamp
+	err = a.db.UpdateVaultTokenLastUsed(ctx, claims.TokenID)
+	if err != nil {
+		// Log error but don't fail the request
+		// TODO: Add proper logging
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+
 	return claims, nil
 }
 
 // RefreshToken refreshes a JWT token while preserving the public key
 func (a *AuthService) RefreshToken(oldToken string) (string, error) {
-	_, err := a.ValidateToken(oldToken)
+	ctx := context.Background()
+
+	claims, err := a.ValidateToken(oldToken)
 	if err != nil {
 		return "", err
 	}
-	return a.GenerateToken()
+
+	// Revoke old token
+	tx, err := a.db.Pool().Begin(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer tx.Rollback(ctx)
+
+	err = a.db.RevokeVaultToken(ctx, claims.TokenID)
+	if err != nil {
+		return "", err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return "", err
+	}
+
+	// Generate new token
+	return a.GenerateToken(claims.PublicKey)
+}
+
+// RevokeToken revokes a specific token
+func (a *AuthService) RevokeToken(tokenID string) error {
+	ctx := context.Background()
+
+	tx, err := a.db.Pool().Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	err = a.db.RevokeVaultToken(ctx, tokenID)
+	if err != nil {
+		return err
+	}
+
+	return tx.Commit(ctx)
+}
+
+// RevokeAllTokens revokes all tokens for a specific public key
+func (a *AuthService) RevokeAllTokens(publicKey string) error {
+	ctx := context.Background()
+
+	tx, err := a.db.Pool().Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	err = a.db.RevokeAllVaultTokens(ctx, publicKey)
+	if err != nil {
+		return err
+	}
+
+	return tx.Commit(ctx)
+}
+
+// GetActiveTokens returns all active tokens for a public key
+func (a *AuthService) GetActiveTokens(publicKey string) ([]types.VaultToken, error) {
+	ctx := context.Background()
+
+	tx, err := a.db.Pool().Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx)
+
+	tokens, err := a.db.GetActiveVaultTokens(ctx, publicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+
+	return tokens, nil
 }

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -93,7 +93,6 @@ func (a *AuthService) GenerateToken(publicKey string) (string, error) {
 	_, err = a.db.CreateVaultToken(context.Background(), types.VaultTokenCreate{
 		PublicKey: publicKey,
 		TokenID:   tokenID,
-		PublicKey: publicKey,
 		ExpiresAt: expirationTime,
 	})
 	if err != nil {

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -39,19 +39,27 @@ func (a *AuthService) GenerateToken() (string, error) {
 	return token.SignedString(a.JWTSecret)
 }
 
-// ValidateToken validates a JWT token
+// ValidateToken validates a JWT token and returns the claims
 func (a *AuthService) ValidateToken(tokenStr string) (*Claims, error) {
 	claims := &Claims{}
 	token, err := jwt.ParseWithClaims(tokenStr, claims, func(token *jwt.Token) (interface{}, error) {
+		// Validate signing method
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, errors.New("unexpected signing method")
+		}
 		return a.JWTSecret, nil
 	})
-	if err != nil || !token.Valid {
+	if err != nil {
+		return nil, errors.New("invalid token: " + err.Error())
+	}
+	if !token.Valid {
 		return nil, errors.New("invalid or expired token")
 	}
+
 	return claims, nil
 }
 
-// RefreshToken refreshes a JWT token
+// RefreshToken refreshes a JWT token while preserving the public key
 func (a *AuthService) RefreshToken(oldToken string) (string, error) {
 	_, err := a.ValidateToken(oldToken)
 	if err != nil {

--- a/internal/service/auth_test.go
+++ b/internal/service/auth_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vultisig/verifier/internal/service"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"

--- a/internal/service/auth_test.go
+++ b/internal/service/auth_test.go
@@ -64,8 +64,70 @@ func (p *mockPool) Begin(ctx context.Context) (pgx.Tx, error) {
 	return &noopTx{}, nil
 }
 
+func (p *mockPool) BeginTx(ctx context.Context, txOptions pgx.TxOptions) (pgx.Tx, error) {
+	return &noopTx{}, nil
+}
+
+func (p *mockPool) Acquire(ctx context.Context) (*pgxpool.Conn, error) {
+	return nil, nil
+}
+
+func (p *mockPool) AcquireAllIdle(ctx context.Context) []*pgxpool.Conn {
+	return nil
+}
+
+func (p *mockPool) AcquireFunc(ctx context.Context, f func(*pgxpool.Conn) error) error {
+	return nil
+}
+
+func (p *mockPool) BeginFunc(ctx context.Context, f func(pgx.Tx) error) error {
+	return nil
+}
+
+func (p *mockPool) BeginTxFunc(ctx context.Context, txOptions pgx.TxOptions, f func(pgx.Tx) error) error {
+	return nil
+}
+
+func (p *mockPool) Close() {}
+
+func (p *mockPool) Config() *pgxpool.Config {
+	return nil
+}
+
+func (p *mockPool) Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, nil
+}
+
+func (p *mockPool) Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error) {
+	return nil, nil
+}
+
+func (p *mockPool) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row {
+	return nil
+}
+
+func (p *mockPool) SendBatch(ctx context.Context, b *pgx.Batch) pgx.BatchResults {
+	return nil
+}
+
+func (p *mockPool) CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNames []string, rowSrc pgx.CopyFromSource) (int64, error) {
+	return 0, nil
+}
+
+func (p *mockPool) Ping(ctx context.Context) error {
+	return nil
+}
+
+func (p *mockPool) Stat() *pgxpool.Stat {
+	return nil
+}
+
 func (m *MockDatabaseStorage) Pool() *pgxpool.Pool {
-	return &pgxpool.Pool{}
+	pool, err := pgxpool.New(context.Background(), "postgres://mock")
+	if err != nil {
+		return nil
+	}
+	return pool
 }
 
 func (m *MockDatabaseStorage) FindUserById(ctx context.Context, userId string) (*itypes.User, error) {
@@ -307,7 +369,7 @@ func TestGenerateToken(t *testing.T) {
 			}, nil)
 
 			// Setup mock expectations
-			mockDB.On("Pool").Return(&pgxpool.Pool{})
+			mockDB.On("Pool").Return(&mockPool{})
 			mockDB.On("CreateVaultToken", mock.Anything, mock.Anything).Return(&itypes.VaultToken{
 				ID:        uuid.New().String(),
 				PublicKey: "test-public-key",

--- a/internal/service/auth_test.go
+++ b/internal/service/auth_test.go
@@ -7,29 +7,76 @@ import (
 	"github.com/vultisig/verifier/internal/service"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
+
+// MockDatabaseStorage is a mock implementation of storage.DatabaseStorage
+type MockDatabaseStorage struct {
+	mock.Mock
+}
+
+func (m *MockDatabaseStorage) Pool() *pgxpool.Pool {
+	return nil
+}
+
+func (m *MockDatabaseStorage) CreateVaultToken(ctx interface{}, token interface{}) (interface{}, error) {
+	args := m.Called(ctx, token)
+	return args.Get(0), args.Error(1)
+}
+
+func (m *MockDatabaseStorage) GetVaultToken(ctx interface{}, tokenID string) (interface{}, error) {
+	args := m.Called(ctx, tokenID)
+	return args.Get(0), args.Error(1)
+}
+
+func (m *MockDatabaseStorage) RevokeVaultToken(ctx interface{}, tokenID string) error {
+	args := m.Called(ctx, tokenID)
+	return args.Error(0)
+}
+
+func (m *MockDatabaseStorage) RevokeAllVaultTokens(ctx interface{}, publicKey string) error {
+	args := m.Called(ctx, publicKey)
+	return args.Error(0)
+}
+
+func (m *MockDatabaseStorage) UpdateVaultTokenLastUsed(ctx interface{}, tokenID string) error {
+	args := m.Called(ctx, tokenID)
+	return args.Error(0)
+}
+
+func (m *MockDatabaseStorage) GetActiveVaultTokens(ctx interface{}, publicKey string) ([]interface{}, error) {
+	args := m.Called(ctx, publicKey)
+	return args.Get(0).([]interface{}), args.Error(1)
+}
 
 func TestGenerateToken(t *testing.T) {
 	testCases := []struct {
 		name        string
 		secret      string
+		publicKey   string
 		shouldError bool
 	}{
 		{
 			name:        "Valid secret",
 			secret:      "secret-key-for-testing",
+			publicKey:   "0x1234567890abcdef",
 			shouldError: false,
 		},
 		{
 			name:        "Empty secret",
 			secret:      "",
+			publicKey:   "0x1234567890abcdef",
 			shouldError: false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			mockDB := new(MockDatabaseStorage)
+			mockDB.On("CreateVaultToken", mock.Anything, mock.Anything).Return(nil, nil)
+
 			authService := service.NewAuthService(tc.secret)
 			token, err := authService.GenerateToken()
 
@@ -57,6 +104,11 @@ func TestValidateToken(t *testing.T) {
 		{
 			name: "Valid token",
 			setupToken: func() string {
+				mockDB := new(MockDatabaseStorage)
+				mockDB.On("CreateVaultToken", mock.Anything, mock.Anything).Return(nil, nil)
+				mockDB.On("GetVaultToken", mock.Anything, mock.Anything).Return(nil, nil)
+				mockDB.On("UpdateVaultTokenLastUsed", mock.Anything, mock.Anything).Return(nil)
+
 				auth := service.NewAuthService(secret)
 				token, _ := auth.GenerateToken()
 				return token
@@ -98,6 +150,11 @@ func TestValidateToken(t *testing.T) {
 		{
 			name: "Wrong secret",
 			setupToken: func() string {
+				mockDB := new(MockDatabaseStorage)
+				mockDB.On("CreateVaultToken", mock.Anything, mock.Anything).Return(nil, nil)
+				mockDB.On("GetVaultToken", mock.Anything, mock.Anything).Return(nil, nil)
+				mockDB.On("UpdateVaultTokenLastUsed", mock.Anything, mock.Anything).Return(nil)
+
 				auth := service.NewAuthService(secret)
 				token, _ := auth.GenerateToken()
 				return token
@@ -118,6 +175,10 @@ func TestValidateToken(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			tokenString := tc.setupToken()
+			mockDB := new(MockDatabaseStorage)
+			mockDB.On("GetVaultToken", mock.Anything, mock.Anything).Return(nil, nil)
+			mockDB.On("UpdateVaultTokenLastUsed", mock.Anything, mock.Anything).Return(nil)
+
 			authService := service.NewAuthService(tc.secret)
 
 			claims, err := authService.ValidateToken(tokenString)
@@ -145,6 +206,12 @@ func TestRefreshToken(t *testing.T) {
 		{
 			name: "Valid token refresh",
 			setupToken: func() string {
+				mockDB := new(MockDatabaseStorage)
+				mockDB.On("CreateVaultToken", mock.Anything, mock.Anything).Return(nil, nil)
+				mockDB.On("GetVaultToken", mock.Anything, mock.Anything).Return(nil, nil)
+				mockDB.On("UpdateVaultTokenLastUsed", mock.Anything, mock.Anything).Return(nil)
+				mockDB.On("RevokeVaultToken", mock.Anything, mock.Anything).Return(nil)
+
 				auth := service.NewAuthService(secret)
 				token, _ := auth.GenerateToken()
 				time.Sleep(1 * time.Second)
@@ -178,6 +245,12 @@ func TestRefreshToken(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			tokenString := tc.setupToken()
+			mockDB := new(MockDatabaseStorage)
+			mockDB.On("CreateVaultToken", mock.Anything, mock.Anything).Return(nil, nil)
+			mockDB.On("GetVaultToken", mock.Anything, mock.Anything).Return(nil, nil)
+			mockDB.On("UpdateVaultTokenLastUsed", mock.Anything, mock.Anything).Return(nil)
+			mockDB.On("RevokeVaultToken", mock.Anything, mock.Anything).Return(nil)
+
 			authService := service.NewAuthService(secret)
 
 			// For valid tokens, we need to guarantee a different ExpiresAt

--- a/internal/service/auth_test.go
+++ b/internal/service/auth_test.go
@@ -17,9 +17,14 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
+
+const testPublicKey = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
+var testLogger = logrus.New()
 
 // MockDatabaseStorage is a mock implementation of storage.DatabaseStorage
 type MockDatabaseStorage struct {

--- a/internal/service/auth_test.go
+++ b/internal/service/auth_test.go
@@ -177,6 +177,9 @@ func (m *MockDatabaseStorage) UpdateVaultTokenLastUsed(ctx context.Context, toke
 
 func (m *MockDatabaseStorage) GetActiveVaultTokens(ctx context.Context, publicKey string) ([]itypes.VaultToken, error) {
 	args := m.Called(ctx, publicKey)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
 	return args.Get(0).([]itypes.VaultToken), args.Error(1)
 }
 
@@ -194,6 +197,9 @@ func (m *MockDatabaseStorage) Close() error {
 // CountTransactions is a stub to satisfy the DatabaseStorage interface
 func (m *MockDatabaseStorage) CountTransactions(ctx context.Context, policyID uuid.UUID, status itypes.TransactionStatus, txType string) (int64, error) {
 	args := m.Called(ctx, policyID, status, txType)
+	if args.Get(0) == nil {
+		return 0, args.Error(1)
+	}
 	return args.Get(0).(int64), args.Error(1)
 }
 
@@ -218,12 +224,18 @@ func (m *MockDatabaseStorage) CreatePricing(ctx context.Context, pricingDto ityp
 // CreateTransactionHistory is a stub to satisfy the DatabaseStorage interface
 func (m *MockDatabaseStorage) CreateTransactionHistory(ctx context.Context, tx itypes.TransactionHistory) (uuid.UUID, error) {
 	args := m.Called(ctx, tx)
+	if args.Get(0) == nil {
+		return uuid.Nil, args.Error(1)
+	}
 	return args.Get(0).(uuid.UUID), args.Error(1)
 }
 
 // CreateTransactionHistoryTx is a stub to satisfy the DatabaseStorage interface
 func (m *MockDatabaseStorage) CreateTransactionHistoryTx(ctx context.Context, dbTx pgx.Tx, tx itypes.TransactionHistory) (uuid.UUID, error) {
 	args := m.Called(ctx, dbTx, tx)
+	if args.Get(0) == nil {
+		return uuid.Nil, args.Error(1)
+	}
 	return args.Get(0).(uuid.UUID), args.Error(1)
 }
 
@@ -255,11 +267,17 @@ func (m *MockDatabaseStorage) UpdatePlugin(ctx context.Context, id uuid.UUID, up
 
 func (m *MockDatabaseStorage) GetPluginPolicy(ctx context.Context, id uuid.UUID) (types.PluginPolicy, error) {
 	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return types.PluginPolicy{}, args.Error(1)
+	}
 	return args.Get(0).(types.PluginPolicy), args.Error(1)
 }
 
 func (m *MockDatabaseStorage) GetAllPluginPolicies(ctx context.Context, publicKey string, pluginType string) ([]types.PluginPolicy, error) {
 	args := m.Called(ctx, publicKey, pluginType)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
 	return args.Get(0).([]types.PluginPolicy), args.Error(1)
 }
 
@@ -304,6 +322,9 @@ func (m *MockDatabaseStorage) UpdateTransactionStatusTx(ctx context.Context, dbT
 
 func (m *MockDatabaseStorage) GetTransactionHistory(ctx context.Context, policyID uuid.UUID, transactionType string, take int, skip int) ([]itypes.TransactionHistory, error) {
 	args := m.Called(ctx, policyID, transactionType, take, skip)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
 	return args.Get(0).([]itypes.TransactionHistory), args.Error(1)
 }
 
@@ -330,6 +351,9 @@ func (m *MockDatabaseStorage) DeletePluginPolicySync(ctx context.Context, id uui
 
 func (m *MockDatabaseStorage) GetUnFinishedPluginPolicySyncs(ctx context.Context) ([]itypes.PluginPolicySync, error) {
 	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
 	return args.Get(0).([]itypes.PluginPolicySync), args.Error(1)
 }
 

--- a/internal/service/auth_test.go
+++ b/internal/service/auth_test.go
@@ -58,74 +58,74 @@ func (t *noopTx) SendBatch(_ context.Context, _ *pgx.Batch) pgx.BatchResults {
 }
 
 // mockPool is a lightweight pool stub that satisfies pgxpool.Pool interface
-type mockPool struct{}
+type mockPool struct {
+	pgxpool.Pool
+}
 
-func (p *mockPool) Begin(ctx context.Context) (pgx.Tx, error) {
+func (m *mockPool) Begin(ctx context.Context) (pgx.Tx, error) {
 	return &noopTx{}, nil
 }
 
-func (p *mockPool) BeginTx(ctx context.Context, txOptions pgx.TxOptions) (pgx.Tx, error) {
+func (m *mockPool) BeginTx(ctx context.Context, txOptions pgx.TxOptions) (pgx.Tx, error) {
 	return &noopTx{}, nil
 }
 
-func (p *mockPool) Acquire(ctx context.Context) (*pgxpool.Conn, error) {
+func (m *mockPool) Acquire(ctx context.Context) (*pgxpool.Conn, error) {
 	return nil, nil
 }
 
-func (p *mockPool) AcquireAllIdle(ctx context.Context) []*pgxpool.Conn {
+func (m *mockPool) AcquireAllIdle(ctx context.Context) []*pgxpool.Conn {
 	return nil
 }
 
-func (p *mockPool) AcquireFunc(ctx context.Context, f func(*pgxpool.Conn) error) error {
+func (m *mockPool) AcquireFunc(ctx context.Context, f func(*pgxpool.Conn) error) error {
 	return nil
 }
 
-func (p *mockPool) BeginFunc(ctx context.Context, f func(pgx.Tx) error) error {
+func (m *mockPool) BeginFunc(ctx context.Context, f func(pgx.Tx) error) error {
 	return nil
 }
 
-func (p *mockPool) BeginTxFunc(ctx context.Context, txOptions pgx.TxOptions, f func(pgx.Tx) error) error {
+func (m *mockPool) BeginTxFunc(ctx context.Context, txOptions pgx.TxOptions, f func(pgx.Tx) error) error {
 	return nil
 }
 
-func (p *mockPool) Close() {}
+func (m *mockPool) Close() {}
 
-func (p *mockPool) Config() *pgxpool.Config {
+func (m *mockPool) Config() *pgxpool.Config {
 	return nil
 }
 
-func (p *mockPool) Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error) {
+func (m *mockPool) Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error) {
 	return pgconn.CommandTag{}, nil
 }
 
-func (p *mockPool) Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error) {
+func (m *mockPool) Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error) {
 	return nil, nil
 }
 
-func (p *mockPool) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row {
+func (m *mockPool) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row {
 	return nil
 }
 
-func (p *mockPool) SendBatch(ctx context.Context, b *pgx.Batch) pgx.BatchResults {
+func (m *mockPool) SendBatch(ctx context.Context, b *pgx.Batch) pgx.BatchResults {
 	return nil
 }
 
-func (p *mockPool) CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNames []string, rowSrc pgx.CopyFromSource) (int64, error) {
+func (m *mockPool) CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNames []string, rowSrc pgx.CopyFromSource) (int64, error) {
 	return 0, nil
 }
 
-func (p *mockPool) Ping(ctx context.Context) error {
+func (m *mockPool) Ping(ctx context.Context) error {
 	return nil
 }
 
-func (p *mockPool) Stat() *pgxpool.Stat {
+func (m *mockPool) Stat() *pgxpool.Stat {
 	return nil
 }
 
 func (m *MockDatabaseStorage) Pool() *pgxpool.Pool {
-	config, _ := pgxpool.ParseConfig("mock://")
-	pool, _ := pgxpool.NewWithConfig(context.Background(), config)
-	return pool
+	return &pgxpool.Pool{}
 }
 
 func (m *MockDatabaseStorage) FindUserById(ctx context.Context, userId string) (*itypes.User, error) {

--- a/internal/service/auth_test.go
+++ b/internal/service/auth_test.go
@@ -130,7 +130,7 @@ func (m *mockPool) Stat() *pgxpool.Stat {
 }
 
 func (m *MockDatabaseStorage) Pool() *pgxpool.Pool {
-	return &pgxpool.Pool{}
+	return &mockPool{}
 }
 
 func (m *MockDatabaseStorage) FindUserById(ctx context.Context, userId string) (*itypes.User, error) {

--- a/internal/service/auth_test.go
+++ b/internal/service/auth_test.go
@@ -4,6 +4,14 @@ import (
 	"testing"
 	"time"
 
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	itypes "github.com/vultisig/verifier/internal/types"
+	"github.com/vultisig/verifier/types"
+
 	"github.com/vultisig/verifier/internal/service"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -21,34 +29,219 @@ func (m *MockDatabaseStorage) Pool() *pgxpool.Pool {
 	return nil
 }
 
-func (m *MockDatabaseStorage) CreateVaultToken(ctx interface{}, token interface{}) (interface{}, error) {
+func (m *MockDatabaseStorage) FindUserById(ctx context.Context, userId string) (*itypes.User, error) {
+	args := m.Called(ctx, userId)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*itypes.User), args.Error(1)
+}
+
+func (m *MockDatabaseStorage) FindUserByName(ctx context.Context, username string) (*itypes.UserWithPassword, error) {
+	args := m.Called(ctx, username)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*itypes.UserWithPassword), args.Error(1)
+}
+
+func (m *MockDatabaseStorage) CreateVaultToken(ctx context.Context, token itypes.VaultTokenCreate) (*itypes.VaultToken, error) {
 	args := m.Called(ctx, token)
-	return args.Get(0), args.Error(1)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*itypes.VaultToken), args.Error(1)
 }
 
-func (m *MockDatabaseStorage) GetVaultToken(ctx interface{}, tokenID string) (interface{}, error) {
+func (m *MockDatabaseStorage) GetVaultToken(ctx context.Context, tokenID string) (*itypes.VaultToken, error) {
 	args := m.Called(ctx, tokenID)
-	return args.Get(0), args.Error(1)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*itypes.VaultToken), args.Error(1)
 }
 
-func (m *MockDatabaseStorage) RevokeVaultToken(ctx interface{}, tokenID string) error {
+func (m *MockDatabaseStorage) RevokeVaultToken(ctx context.Context, tokenID string) error {
 	args := m.Called(ctx, tokenID)
 	return args.Error(0)
 }
 
-func (m *MockDatabaseStorage) RevokeAllVaultTokens(ctx interface{}, publicKey string) error {
+func (m *MockDatabaseStorage) RevokeAllVaultTokens(ctx context.Context, publicKey string) error {
 	args := m.Called(ctx, publicKey)
 	return args.Error(0)
 }
 
-func (m *MockDatabaseStorage) UpdateVaultTokenLastUsed(ctx interface{}, tokenID string) error {
+func (m *MockDatabaseStorage) UpdateVaultTokenLastUsed(ctx context.Context, tokenID string) error {
 	args := m.Called(ctx, tokenID)
 	return args.Error(0)
 }
 
-func (m *MockDatabaseStorage) GetActiveVaultTokens(ctx interface{}, publicKey string) ([]interface{}, error) {
+func (m *MockDatabaseStorage) GetActiveVaultTokens(ctx context.Context, publicKey string) ([]itypes.VaultToken, error) {
 	args := m.Called(ctx, publicKey)
-	return args.Get(0).([]interface{}), args.Error(1)
+	return args.Get(0).([]itypes.VaultToken), args.Error(1)
+}
+
+// AddPluginPolicySync is a stub to satisfy the DatabaseStorage interface
+func (m *MockDatabaseStorage) AddPluginPolicySync(ctx context.Context, tx pgx.Tx, policy itypes.PluginPolicySync) error {
+	args := m.Called(ctx, tx, policy)
+	return args.Error(0)
+}
+
+// Close is a stub to satisfy the DatabaseStorage interface
+func (m *MockDatabaseStorage) Close() error {
+	return nil
+}
+
+// CountTransactions is a stub to satisfy the DatabaseStorage interface
+func (m *MockDatabaseStorage) CountTransactions(ctx context.Context, policyID uuid.UUID, status itypes.TransactionStatus, txType string) (int64, error) {
+	args := m.Called(ctx, policyID, status, txType)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+// CreatePlugin is a stub to satisfy the DatabaseStorage interface
+func (m *MockDatabaseStorage) CreatePlugin(ctx context.Context, pluginDto itypes.PluginCreateDto) (*itypes.Plugin, error) {
+	args := m.Called(ctx, pluginDto)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*itypes.Plugin), args.Error(1)
+}
+
+// CreatePricing is a stub to satisfy the DatabaseStorage interface
+func (m *MockDatabaseStorage) CreatePricing(ctx context.Context, pricingDto itypes.PricingCreateDto) (*itypes.Pricing, error) {
+	args := m.Called(ctx, pricingDto)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*itypes.Pricing), args.Error(1)
+}
+
+// CreateTransactionHistory is a stub to satisfy the DatabaseStorage interface
+func (m *MockDatabaseStorage) CreateTransactionHistory(ctx context.Context, tx itypes.TransactionHistory) (uuid.UUID, error) {
+	args := m.Called(ctx, tx)
+	return args.Get(0).(uuid.UUID), args.Error(1)
+}
+
+// CreateTransactionHistoryTx is a stub to satisfy the DatabaseStorage interface
+func (m *MockDatabaseStorage) CreateTransactionHistoryTx(ctx context.Context, dbTx pgx.Tx, tx itypes.TransactionHistory) (uuid.UUID, error) {
+	args := m.Called(ctx, dbTx, tx)
+	return args.Get(0).(uuid.UUID), args.Error(1)
+}
+
+func (m *MockDatabaseStorage) DeletePluginById(ctx context.Context, id uuid.UUID) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+func (m *MockDatabaseStorage) FindPluginById(ctx context.Context, id uuid.UUID) (*itypes.Plugin, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*itypes.Plugin), args.Error(1)
+}
+
+func (m *MockDatabaseStorage) FindPlugins(ctx context.Context, take int, skip int, sort string) (itypes.PlugisDto, error) {
+	args := m.Called(ctx, take, skip, sort)
+	return args.Get(0).(itypes.PlugisDto), args.Error(1)
+}
+
+func (m *MockDatabaseStorage) UpdatePlugin(ctx context.Context, id uuid.UUID, updates itypes.PluginUpdateDto) (*itypes.Plugin, error) {
+	args := m.Called(ctx, id, updates)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*itypes.Plugin), args.Error(1)
+}
+
+func (m *MockDatabaseStorage) GetPluginPolicy(ctx context.Context, id uuid.UUID) (types.PluginPolicy, error) {
+	args := m.Called(ctx, id)
+	return args.Get(0).(types.PluginPolicy), args.Error(1)
+}
+
+func (m *MockDatabaseStorage) GetAllPluginPolicies(ctx context.Context, publicKey string, pluginType string) ([]types.PluginPolicy, error) {
+	args := m.Called(ctx, publicKey, pluginType)
+	return args.Get(0).([]types.PluginPolicy), args.Error(1)
+}
+
+func (m *MockDatabaseStorage) DeletePluginPolicyTx(ctx context.Context, dbTx pgx.Tx, id uuid.UUID) error {
+	args := m.Called(ctx, dbTx, id)
+	return args.Error(0)
+}
+
+func (m *MockDatabaseStorage) InsertPluginPolicyTx(ctx context.Context, dbTx pgx.Tx, policy types.PluginPolicy) (*types.PluginPolicy, error) {
+	args := m.Called(ctx, dbTx, policy)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*types.PluginPolicy), args.Error(1)
+}
+
+func (m *MockDatabaseStorage) UpdatePluginPolicyTx(ctx context.Context, dbTx pgx.Tx, policy types.PluginPolicy) (*types.PluginPolicy, error) {
+	args := m.Called(ctx, dbTx, policy)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*types.PluginPolicy), args.Error(1)
+}
+
+func (m *MockDatabaseStorage) FindPricingById(ctx context.Context, id string) (*itypes.Pricing, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*itypes.Pricing), args.Error(1)
+}
+
+func (m *MockDatabaseStorage) DeletePricingById(ctx context.Context, id string) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+func (m *MockDatabaseStorage) UpdateTransactionStatusTx(ctx context.Context, dbTx pgx.Tx, txID uuid.UUID, status itypes.TransactionStatus, metadata map[string]interface{}) error {
+	args := m.Called(ctx, dbTx, txID, status, metadata)
+	return args.Error(0)
+}
+
+func (m *MockDatabaseStorage) GetTransactionHistory(ctx context.Context, policyID uuid.UUID, transactionType string, take int, skip int) ([]itypes.TransactionHistory, error) {
+	args := m.Called(ctx, policyID, transactionType, take, skip)
+	return args.Get(0).([]itypes.TransactionHistory), args.Error(1)
+}
+
+func (m *MockDatabaseStorage) GetTransactionByHash(ctx context.Context, txHash string) (*itypes.TransactionHistory, error) {
+	args := m.Called(ctx, txHash)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*itypes.TransactionHistory), args.Error(1)
+}
+
+func (m *MockDatabaseStorage) GetPluginPolicySync(ctx context.Context, id uuid.UUID) (*itypes.PluginPolicySync, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*itypes.PluginPolicySync), args.Error(1)
+}
+
+func (m *MockDatabaseStorage) DeletePluginPolicySync(ctx context.Context, id uuid.UUID) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+func (m *MockDatabaseStorage) GetUnFinishedPluginPolicySyncs(ctx context.Context) ([]itypes.PluginPolicySync, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]itypes.PluginPolicySync), args.Error(1)
+}
+
+func (m *MockDatabaseStorage) UpdatePluginPolicySync(ctx context.Context, dbTx pgx.Tx, policy itypes.PluginPolicySync) error {
+	args := m.Called(ctx, dbTx, policy)
+	return args.Error(0)
+}
+
+func (m *MockDatabaseStorage) UpdateTransactionStatus(ctx context.Context, txID uuid.UUID, status itypes.TransactionStatus, metadata map[string]interface{}) error {
+	args := m.Called(ctx, txID, status, metadata)
+	return args.Error(0)
 }
 
 func TestGenerateToken(t *testing.T) {
@@ -155,8 +348,8 @@ func TestValidateToken(t *testing.T) {
 				mockDB.On("GetVaultToken", mock.Anything, mock.Anything).Return(nil, nil)
 				mockDB.On("UpdateVaultTokenLastUsed", mock.Anything, mock.Anything).Return(nil)
 
-				auth := service.NewAuthService(secret)
-				token, _ := auth.GenerateToken()
+				auth := service.NewAuthService(secret, mockDB)
+				token, _ := auth.GenerateToken(testPublicKey)
 				return token
 			},
 			secret:      wrongSecret,

--- a/internal/service/auth_test.go
+++ b/internal/service/auth_test.go
@@ -57,74 +57,74 @@ func (t *noopTx) SendBatch(_ context.Context, _ *pgx.Batch) pgx.BatchResults {
 }
 
 // mockPool is a lightweight pool stub that satisfies pgxpool.Pool interface
-type mockPool struct{}
+type mockPool struct {
+	pgxpool.Pool
+}
 
-func (p *mockPool) Begin(ctx context.Context) (pgx.Tx, error) {
+func (m *mockPool) Begin(ctx context.Context) (pgx.Tx, error) {
 	return &noopTx{}, nil
 }
 
-func (p *mockPool) BeginTx(ctx context.Context, txOptions pgx.TxOptions) (pgx.Tx, error) {
+func (m *mockPool) BeginTx(ctx context.Context, txOptions pgx.TxOptions) (pgx.Tx, error) {
 	return &noopTx{}, nil
 }
 
-func (p *mockPool) Acquire(ctx context.Context) (*pgxpool.Conn, error) {
+func (m *mockPool) Acquire(ctx context.Context) (*pgxpool.Conn, error) {
 	return nil, nil
 }
 
-func (p *mockPool) AcquireAllIdle(ctx context.Context) []*pgxpool.Conn {
+func (m *mockPool) AcquireAllIdle(ctx context.Context) []*pgxpool.Conn {
 	return nil
 }
 
-func (p *mockPool) AcquireFunc(ctx context.Context, f func(*pgxpool.Conn) error) error {
+func (m *mockPool) AcquireFunc(ctx context.Context, f func(*pgxpool.Conn) error) error {
 	return nil
 }
 
-func (p *mockPool) BeginFunc(ctx context.Context, f func(pgx.Tx) error) error {
+func (m *mockPool) BeginFunc(ctx context.Context, f func(pgx.Tx) error) error {
 	return nil
 }
 
-func (p *mockPool) BeginTxFunc(ctx context.Context, txOptions pgx.TxOptions, f func(pgx.Tx) error) error {
+func (m *mockPool) BeginTxFunc(ctx context.Context, txOptions pgx.TxOptions, f func(pgx.Tx) error) error {
 	return nil
 }
 
-func (p *mockPool) Close() {}
+func (m *mockPool) Close() {}
 
-func (p *mockPool) Config() *pgxpool.Config {
+func (m *mockPool) Config() *pgxpool.Config {
 	return nil
 }
 
-func (p *mockPool) Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error) {
+func (m *mockPool) Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error) {
 	return pgconn.CommandTag{}, nil
 }
 
-func (p *mockPool) Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error) {
+func (m *mockPool) Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error) {
 	return nil, nil
 }
 
-func (p *mockPool) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row {
+func (m *mockPool) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row {
 	return nil
 }
 
-func (p *mockPool) SendBatch(ctx context.Context, b *pgx.Batch) pgx.BatchResults {
+func (m *mockPool) SendBatch(ctx context.Context, b *pgx.Batch) pgx.BatchResults {
 	return nil
 }
 
-func (p *mockPool) CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNames []string, rowSrc pgx.CopyFromSource) (int64, error) {
+func (m *mockPool) CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNames []string, rowSrc pgx.CopyFromSource) (int64, error) {
 	return 0, nil
 }
 
-func (p *mockPool) Ping(ctx context.Context) error {
+func (m *mockPool) Ping(ctx context.Context) error {
 	return nil
 }
 
-func (p *mockPool) Stat() *pgxpool.Stat {
+func (m *mockPool) Stat() *pgxpool.Stat {
 	return nil
 }
 
 func (m *MockDatabaseStorage) Pool() *pgxpool.Pool {
-	config, _ := pgxpool.ParseConfig("mock://")
-	pool, _ := pgxpool.NewWithConfig(context.Background(), config)
-	return pool
+	return &pgxpool.Pool{}
 }
 
 func (m *MockDatabaseStorage) FindUserById(ctx context.Context, userId string) (*itypes.User, error) {

--- a/internal/service/auth_test.go
+++ b/internal/service/auth_test.go
@@ -64,8 +64,70 @@ func (p *mockPool) Begin(ctx context.Context) (pgx.Tx, error) {
 	return &noopTx{}, nil
 }
 
+func (p *mockPool) BeginTx(ctx context.Context, txOptions pgx.TxOptions) (pgx.Tx, error) {
+	return &noopTx{}, nil
+}
+
+func (p *mockPool) Acquire(ctx context.Context) (*pgxpool.Conn, error) {
+	return nil, nil
+}
+
+func (p *mockPool) AcquireAllIdle(ctx context.Context) []*pgxpool.Conn {
+	return nil
+}
+
+func (p *mockPool) AcquireFunc(ctx context.Context, f func(*pgxpool.Conn) error) error {
+	return nil
+}
+
+func (p *mockPool) BeginFunc(ctx context.Context, f func(pgx.Tx) error) error {
+	return nil
+}
+
+func (p *mockPool) BeginTxFunc(ctx context.Context, txOptions pgx.TxOptions, f func(pgx.Tx) error) error {
+	return nil
+}
+
+func (p *mockPool) Close() {}
+
+func (p *mockPool) Config() *pgxpool.Config {
+	return nil
+}
+
+func (p *mockPool) Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, nil
+}
+
+func (p *mockPool) Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error) {
+	return nil, nil
+}
+
+func (p *mockPool) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row {
+	return nil
+}
+
+func (p *mockPool) SendBatch(ctx context.Context, b *pgx.Batch) pgx.BatchResults {
+	return nil
+}
+
+func (p *mockPool) CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNames []string, rowSrc pgx.CopyFromSource) (int64, error) {
+	return 0, nil
+}
+
+func (p *mockPool) Ping(ctx context.Context) error {
+	return nil
+}
+
+func (p *mockPool) Stat() *pgxpool.Stat {
+	return nil
+}
+
 func (m *MockDatabaseStorage) Pool() *pgxpool.Pool {
-	return &pgxpool.Pool{}
+	pool, err := pgxpool.New(context.Background(), "postgres://mock")
+	if err != nil {
+		return nil
+	}
+	return pool
 }
 
 func (m *MockDatabaseStorage) FindUserById(ctx context.Context, userId string) (*itypes.User, error) {
@@ -302,7 +364,7 @@ func TestGenerateToken(t *testing.T) {
 			authService := service.NewAuthService(tt.secret, mockDB)
 
 			// Setup mock expectations
-			mockDB.On("Pool").Return(&pgxpool.Pool{})
+			mockDB.On("Pool").Return(&mockPool{})
 			mockDB.On("CreateVaultToken", mock.Anything, mock.Anything).Return(&itypes.VaultToken{
 				ID:        uuid.New().String(),
 				PublicKey: "test-public-key",

--- a/internal/service/auth_test.go
+++ b/internal/service/auth_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 	itypes "github.com/vultisig/verifier/internal/types"
 	"github.com/vultisig/verifier/types"
 
@@ -123,10 +122,8 @@ func (p *mockPool) Stat() *pgxpool.Stat {
 }
 
 func (m *MockDatabaseStorage) Pool() *pgxpool.Pool {
-	pool, err := pgxpool.New(context.Background(), "postgres://mock")
-	if err != nil {
-		return nil
-	}
+	config, _ := pgxpool.ParseConfig("mock://")
+	pool, _ := pgxpool.NewWithConfig(context.Background(), config)
 	return pool
 }
 
@@ -364,7 +361,6 @@ func TestGenerateToken(t *testing.T) {
 			authService := service.NewAuthService(tt.secret, mockDB)
 
 			// Setup mock expectations
-			mockDB.On("Pool").Return(&mockPool{})
 			mockDB.On("CreateVaultToken", mock.Anything, mock.Anything).Return(&itypes.VaultToken{
 				ID:        uuid.New().String(),
 				PublicKey: "test-public-key",
@@ -397,7 +393,10 @@ func TestValidateToken(t *testing.T) {
 			name: "Valid token",
 			setupToken: func() string {
 				mockDB := new(MockDatabaseStorage)
-				mockDB.On("CreateVaultToken", mock.Anything, mock.Anything).Return(nil, nil)
+				mockDB.On("CreateVaultToken", mock.Anything, mock.Anything).Return(&itypes.VaultToken{
+					TokenID:   "valid-token",
+					IsRevoked: false,
+				}, nil)
 				mockDB.On("GetVaultToken", mock.Anything, mock.Anything).Return(&itypes.VaultToken{
 					TokenID:   "valid-token",
 					IsRevoked: false,
@@ -471,7 +470,10 @@ func TestValidateToken(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tokenString := tc.setupToken()
 			mockDB := new(MockDatabaseStorage)
-			mockDB.On("GetVaultToken", mock.Anything, mock.Anything).Return(nil, nil)
+			mockDB.On("GetVaultToken", mock.Anything, mock.Anything).Return(&itypes.VaultToken{
+				TokenID:   "valid-token",
+				IsRevoked: false,
+			}, nil)
 			mockDB.On("UpdateVaultTokenLastUsed", mock.Anything, mock.Anything).Return(nil)
 
 			authService := service.NewAuthService(tc.secret)

--- a/internal/sigutil/signing.go
+++ b/internal/sigutil/signing.go
@@ -11,7 +11,7 @@ import (
 )
 
 // VerifySignature verifies a signature against a message using a public key
-func VerifySignature(vaultPublicKey string, chainCodeHex string, messageBytes []byte, signatureBytes []byte) (bool, error) {
+func VerifySignature(vaultPublicKey string, messageBytes []byte, signatureBytes []byte) (bool, error) {
 	// Ensure public key has 0x prefix
 	if !strings.HasPrefix(vaultPublicKey, "0x") {
 		vaultPublicKey = "0x" + vaultPublicKey

--- a/internal/sigutil/signing.go
+++ b/internal/sigutil/signing.go
@@ -22,6 +22,11 @@ func VerifySignature(vaultPublicKey string, messageBytes []byte, signatureBytes 
 		return false, fmt.Errorf("invalid signature length: expected 65 bytes, got %d", len(signatureBytes))
 	}
 
+	// Ethereum’s v can be {0,1,27,28,…}. Shift to {27,28} as required by go-ethereum.
+	if signatureBytes[64] < 27 {
+		signatureBytes[64] += 27
+	}
+
 	// Create the Ethereum prefixed message hash
 	prefixedMessage := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", len(messageBytes), messageBytes)
 	prefixedHash := crypto.Keccak256Hash([]byte(prefixedMessage))

--- a/internal/sigutil/signing_test.go
+++ b/internal/sigutil/signing_test.go
@@ -1,0 +1,99 @@
+package sigutil
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVerifyEthAddressSignature(t *testing.T) {
+	// Generate a test key pair
+	privateKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("Failed to generate key: %v", err)
+	}
+	address := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	// Create a test message
+	message := []byte("test message")
+
+	// Sign the message using the standard Ethereum personal_sign method
+	hash := crypto.Keccak256Hash([]byte(fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", len(message), message)))
+	signature, err := crypto.Sign(hash.Bytes(), privateKey)
+	if err != nil {
+		t.Fatalf("Failed to sign message: %v", err)
+	}
+
+	tests := []struct {
+		name          string
+		address       common.Address
+		message       []byte
+		signature     []byte
+		want          bool
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:        "Valid signature",
+			address:     address,
+			message:     message,
+			signature:   signature,
+			want:        true,
+			expectError: false,
+		},
+		{
+			name:          "Invalid signature length",
+			address:       address,
+			message:       message,
+			signature:     []byte{1, 2, 3}, // Too short
+			want:          false,
+			expectError:   true,
+			errorContains: "invalid signature length",
+		},
+		{
+			name:          "Invalid signature bytes",
+			address:       address,
+			message:       message,
+			signature:     make([]byte, 65), // Valid length but invalid content
+			want:          false,
+			expectError:   true,
+			errorContains: "failed to recover public key",
+		},
+		{
+			name:        "Wrong address",
+			address:     common.HexToAddress("0x1234567890123456789012345678901234567890"),
+			message:     message,
+			signature:   signature,
+			want:        false,
+			expectError: false,
+		},
+		{
+			name:        "Empty message",
+			address:     address,
+			message:     []byte{},
+			signature:   signature,
+			want:        false,
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := VerifyEthAddressSignature(tt.address, tt.message, tt.signature)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -23,9 +23,9 @@ type DatabaseStorage interface {
 	InsertPluginPolicyTx(ctx context.Context, dbTx pgx.Tx, policy types.PluginPolicy) (*types.PluginPolicy, error)
 	UpdatePluginPolicyTx(ctx context.Context, dbTx pgx.Tx, policy types.PluginPolicy) (*types.PluginPolicy, error)
 
-	FindPricingById(ctx context.Context, id string) (*itypes.Pricing, error)
+	FindPricingById(ctx context.Context, id uuid.UUID) (*itypes.Pricing, error)
 	CreatePricing(ctx context.Context, pricingDto itypes.PricingCreateDto) (*itypes.Pricing, error)
-	DeletePricingById(ctx context.Context, id string) error
+	DeletePricingById(ctx context.Context, id uuid.UUID) error
 
 	CountTransactions(ctx context.Context, policyID uuid.UUID, status itypes.TransactionStatus, txType string) (int64, error)
 	CreateTransactionHistoryTx(ctx context.Context, dbTx pgx.Tx, tx itypes.TransactionHistory) (uuid.UUID, error)

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -17,6 +17,14 @@ type DatabaseStorage interface {
 	FindUserById(ctx context.Context, userId string) (*itypes.User, error)
 	FindUserByName(ctx context.Context, username string) (*itypes.UserWithPassword, error)
 
+	// Vault Token methods
+	CreateVaultToken(ctx context.Context, token itypes.VaultTokenCreate) (*itypes.VaultToken, error)
+	GetVaultToken(ctx context.Context, tokenID string) (*itypes.VaultToken, error)
+	RevokeVaultToken(ctx context.Context, tokenID string) error
+	RevokeAllVaultTokens(ctx context.Context, publicKey string) error
+	UpdateVaultTokenLastUsed(ctx context.Context, tokenID string) error
+	GetActiveVaultTokens(ctx context.Context, publicKey string) ([]itypes.VaultToken, error)
+
 	GetPluginPolicy(ctx context.Context, id uuid.UUID) (types.PluginPolicy, error)
 	GetAllPluginPolicies(ctx context.Context, publicKey string, pluginType string) ([]types.PluginPolicy, error)
 	DeletePluginPolicyTx(ctx context.Context, dbTx pgx.Tx, id uuid.UUID) error

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -35,7 +35,7 @@ type DatabaseStorage interface {
 	GetTransactionHistory(ctx context.Context, policyID uuid.UUID, transactionType string, take int, skip int) ([]itypes.TransactionHistory, error)
 	GetTransactionByHash(ctx context.Context, txHash string) (*itypes.TransactionHistory, error)
 
-	FindPlugins(ctx context.Context, take int, skip int, sort string) (itypes.PlugisDto, error)
+	FindPlugins(ctx context.Context, take int, skip int, sort string) (itypes.PluginsDto, error)
 	FindPluginById(ctx context.Context, id uuid.UUID) (*itypes.Plugin, error)
 	CreatePlugin(ctx context.Context, pluginDto itypes.PluginCreateDto) (*itypes.Plugin, error)
 	UpdatePlugin(ctx context.Context, id uuid.UUID, updates itypes.PluginUpdateDto) (*itypes.Plugin, error)

--- a/internal/storage/postgres/db.go
+++ b/internal/storage/postgres/db.go
@@ -44,20 +44,20 @@ func NewPostgresBackend(dsn string) (*PostgresBackend, error) {
 	return backend, nil
 }
 
-func (d *PostgresBackend) Close() error {
-	d.pool.Close()
+func (p *PostgresBackend) Close() error {
+	p.pool.Close()
 
 	return nil
 }
 
-func (d *PostgresBackend) Migrate() error {
+func (p *PostgresBackend) Migrate() error {
 	logrus.Info("Starting database migration...")
 	goose.SetBaseFS(embeddedMigrations)
 	if err := goose.SetDialect("postgres"); err != nil {
 		return fmt.Errorf("failed to set goose dialect: %w", err)
 	}
 
-	db := stdlib.OpenDBFromPool(d.pool)
+	db := stdlib.OpenDBFromPool(p.pool)
 	if err := goose.Up(db, "migrations"); err != nil {
 		return fmt.Errorf("failed to run goose up: %w", err)
 	}

--- a/internal/storage/postgres/db_test.go
+++ b/internal/storage/postgres/db_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAddPluginPolicySync(t *testing.T) {
-	t.SkipNow()
+	t.Skip("Skipping postgres test")
 	db, err := NewPostgresBackend("user=myuser password=mypassword dbname=vultisig-verifier host=localhost port=5432 sslmode=disable")
 	assert.NoError(t, err)
 	ctx := context.Background()

--- a/internal/storage/postgres/migrations/20240320000000_add_vault_tokens.sql
+++ b/internal/storage/postgres/migrations/20240320000000_add_vault_tokens.sql
@@ -1,0 +1,25 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE vault_tokens (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    public_key TEXT NOT NULL,
+    token_id TEXT NOT NULL,  -- First part of JWT for identification
+    issued_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    is_revoked BOOLEAN DEFAULT FALSE,
+    last_used_at TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP    
+    CONSTRAINT unique_token_id UNIQUE (token_id)
+);
+
+-- Indexes for faster lookups
+CREATE INDEX idx_vault_tokens_public_key ON vault_tokens(public_key);
+CREATE INDEX idx_vault_tokens_token_id ON vault_tokens(token_id);
+CREATE INDEX idx_vault_tokens_is_revoked ON vault_tokens(is_revoked);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS vault_tokens;
+-- +goose StatementEnd 

--- a/internal/storage/postgres/migrations/20250513034103_remove_chaincode_isecdsa.sql
+++ b/internal/storage/postgres/migrations/20250513034103_remove_chaincode_isecdsa.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE plugin_policies
+  DROP COLUMN IF EXISTS chain_code_hex;
+ALTER TABLE plugin_policies
+  DROP COLUMN IF EXISTS is_ecdsa;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE plugin_policies
+  ADD COLUMN IF NOT EXISTS chain_code_hex TEXT NOT NULL;
+ALTER TABLE plugin_policies
+  ADD COLUMN IF NOT EXISTS is_ecdsa BOOLEAN DEFAULT TRUE;
+-- +goose StatementEnd

--- a/internal/storage/postgres/plugin.go
+++ b/internal/storage/postgres/plugin.go
@@ -2,7 +2,10 @@ package postgres
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"reflect"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -117,15 +120,48 @@ func (p *PostgresBackend) CreatePlugin(ctx context.Context, pluginDto types.Plug
 }
 
 func (p *PostgresBackend) UpdatePlugin(ctx context.Context, id uuid.UUID, updates types.PluginUpdateDto) (*types.Plugin, error) {
-	query := fmt.Sprintf(`UPDATE plugins SET title = @Title, description = @Description, metadata = @Metadata, server_endpoint = @ServerEndpoint, pricing_id = @PricingID WHERE id = @id;`)
+	t := reflect.TypeOf(updates)
+	v := reflect.ValueOf(updates)
+	numFields := t.NumField()
+
+	query := fmt.Sprintf(`UPDATE %s SET `, PLUGINS_TABLE)
+
 	args := pgx.NamedArgs{
-		"Title":          updates.Title,
-		"Description":    updates.Description,
-		"Metadata":       updates.Metadata,
-		"ServerEndpoint": updates.ServerEndpoint,
-		"PricingID":      updates.PricingID,
-		"id":             id,
+		"id": id,
 	}
+
+	// iterate over dto props and assign non-empty for update
+	var updateStatements []string
+	for i := 0; i < numFields; i++ {
+		field := t.Field(i) // field metadata
+		value := v.Field(i) // field value
+
+		// filter out json undefined values
+		if !value.IsNil() {
+			// get db field name (same as it is defined in the json input)
+			fieldName := field.Tag.Get("json")
+			if fieldName == "" {
+				// fallback to prop name
+				fieldName = field.Name
+			}
+
+			// get value from dto reference
+			var fieldValue interface{}
+			if field.Type == reflect.TypeOf((*json.RawMessage)(nil)) {
+				// keep as reference to []byte
+				fieldValue = value.Interface().(*json.RawMessage)
+			} else {
+				// dereference
+				fieldValue = value.Elem().Interface()
+			}
+
+			updateStatements = append(updateStatements, fmt.Sprintf("%s = @%s", fieldName, fieldName))
+			args[fieldName] = fieldValue
+		}
+	}
+
+	query += strings.Join(updateStatements, ", ") + ` WHERE id = @id`
+
 	_, err := p.pool.Exec(ctx, query, args)
 	if err != nil {
 		return nil, err

--- a/internal/storage/postgres/plugin.go
+++ b/internal/storage/postgres/plugin.go
@@ -29,9 +29,9 @@ func (p *PostgresBackend) FindPluginById(ctx context.Context, id uuid.UUID) (*ty
 	return &plugin, nil
 }
 
-func (p *PostgresBackend) FindPlugins(ctx context.Context, skip int, take int, sort string) (types.PlugisDto, error) {
+func (p *PostgresBackend) FindPlugins(ctx context.Context, take int, skip int, sort string) (types.PluginsDto, error) {
 	if p.pool == nil {
-		return types.PlugisDto{}, fmt.Errorf("database pool is nil")
+		return types.PluginsDto{}, fmt.Errorf("database pool is nil")
 	}
 
 	orderBy, orderDirection := common.GetSortingCondition(sort)
@@ -44,7 +44,7 @@ func (p *PostgresBackend) FindPlugins(ctx context.Context, skip int, take int, s
 
 	rows, err := p.pool.Query(ctx, query, take, skip)
 	if err != nil {
-		return types.PlugisDto{}, err
+		return types.PluginsDto{}, err
 	}
 
 	defer rows.Close()
@@ -68,13 +68,13 @@ func (p *PostgresBackend) FindPlugins(ctx context.Context, skip int, take int, s
 			&totalCount,
 		)
 		if err != nil {
-			return types.PlugisDto{}, err
+			return types.PluginsDto{}, err
 		}
 
 		plugins = append(plugins, plugin)
 	}
 
-	pluginsDto := types.PlugisDto{
+	pluginsDto := types.PluginsDto{
 		Plugins:    plugins,
 		TotalCount: totalCount,
 	}

--- a/internal/storage/postgres/policy.go
+++ b/internal/storage/postgres/policy.go
@@ -22,15 +22,13 @@ func (p *PostgresBackend) GetPluginPolicy(ctx context.Context, id uuid.UUID) (ty
 	var policyJSON []byte
 
 	query := `
-        SELECT id, public_key, is_ecdsa, chain_code_hex, plugin_id, plugin_version, policy_version, plugin_type, signature, active, policy 
+        SELECT id, public_key,  plugin_id, plugin_version, policy_version, plugin_type, signature, active, policy 
         FROM plugin_policies 
         WHERE id = $1`
 
 	err := p.pool.QueryRow(ctx, query, id).Scan(
 		&policy.ID,
 		&policy.PublicKey,
-		&policy.IsEcdsa,
-		&policy.ChainCodeHex,
 		&policy.PluginID,
 		&policy.PluginVersion,
 		&policy.PolicyVersion,
@@ -54,7 +52,7 @@ func (p *PostgresBackend) GetAllPluginPolicies(ctx context.Context, publicKey st
 	}
 
 	query := `
-  	SELECT id, public_key, is_ecdsa, chain_code_hex, plugin_id, plugin_version, policy_version, plugin_type, signature, active, policy 
+  	SELECT id, public_key,  plugin_id, plugin_version, policy_version, plugin_type, signature, active, policy 
 		FROM plugin_policies
 		WHERE public_key = $1
 		AND plugin_type = $2`
@@ -70,8 +68,6 @@ func (p *PostgresBackend) GetAllPluginPolicies(ctx context.Context, publicKey st
 		err := rows.Scan(
 			&policy.ID,
 			&policy.PublicKey,
-			&policy.IsEcdsa,
-			&policy.ChainCodeHex,
 			&policy.PluginID,
 			&policy.PluginVersion,
 			&policy.PolicyVersion,
@@ -97,17 +93,15 @@ func (p *PostgresBackend) InsertPluginPolicyTx(ctx context.Context, dbTx pgx.Tx,
 
 	query := `
   	INSERT INTO plugin_policies (
-      id, public_key, is_ecdsa, chain_code_hex, plugin_id, plugin_version, policy_version, plugin_type, signature, active, policy
-    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-    RETURNING id, public_key, is_ecdsa, chain_code_hex, plugin_id, plugin_version, policy_version, plugin_type, signature, active, policy
+      id, public_key, plugin_id, plugin_version, policy_version, plugin_type, signature, active, policy
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+    RETURNING id, public_key, plugin_id, plugin_version, policy_version, plugin_type, signature, active, policy
 	`
 
 	var insertedPolicy types.PluginPolicy
 	err = dbTx.QueryRow(ctx, query,
 		policy.ID,
 		policy.PublicKey,
-		policy.IsEcdsa,
-		policy.ChainCodeHex,
 		policy.PluginID,
 		policy.PluginVersion,
 		policy.PolicyVersion,
@@ -118,8 +112,6 @@ func (p *PostgresBackend) InsertPluginPolicyTx(ctx context.Context, dbTx pgx.Tx,
 	).Scan(
 		&insertedPolicy.ID,
 		&insertedPolicy.PublicKey,
-		&insertedPolicy.IsEcdsa,
-		&insertedPolicy.ChainCodeHex,
 		&insertedPolicy.PluginID,
 		&insertedPolicy.PluginVersion,
 		&insertedPolicy.PolicyVersion,
@@ -141,14 +133,13 @@ func (p *PostgresBackend) UpdatePluginPolicyTx(ctx context.Context, dbTx pgx.Tx,
 		return nil, fmt.Errorf("failed to marshal policy: %w", err)
 	}
 
-	// TODO: update other fields
 	query := `
 		UPDATE plugin_policies 
-		SET public_key = $2, 
-				plugin_type = $3, 
-				signature = $4,
-				active = $5,
-				policy = $6
+		SET plugin_version = $2,
+		    policy_version = $3,
+			signature = $4,
+			active = $5,
+			policy = $6
 		WHERE id = $1
 		RETURNING id, public_key, plugin_id, plugin_version, policy_version, plugin_type, signature, active, policy
 	`
@@ -156,12 +147,11 @@ func (p *PostgresBackend) UpdatePluginPolicyTx(ctx context.Context, dbTx pgx.Tx,
 	var updatedPolicy types.PluginPolicy
 	err = dbTx.QueryRow(ctx, query,
 		policy.ID,
-		policy.PublicKey,
-		policy.PluginType,
+		policy.PluginVersion,
+		policy.PolicyVersion,
 		policy.Signature,
 		policy.Active,
-		policyJSON,
-	).Scan(
+		policyJSON).Scan(
 		&updatedPolicy.ID,
 		&updatedPolicy.PublicKey,
 		&updatedPolicy.PluginID,

--- a/internal/storage/postgres/pricing.go
+++ b/internal/storage/postgres/pricing.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 
 	"github.com/vultisig/verifier/internal/types"
@@ -12,7 +13,7 @@ import (
 
 const PRICINGS_TABLE = "pricings"
 
-func (p *PostgresBackend) FindPricingById(ctx context.Context, id string) (*types.Pricing, error) {
+func (p *PostgresBackend) FindPricingById(ctx context.Context, id uuid.UUID) (*types.Pricing, error) {
 	query := fmt.Sprintf(`SELECT * FROM %s WHERE id = $1 LIMIT 1;`, PRICINGS_TABLE)
 
 	rows, err := p.pool.Query(ctx, query, id)
@@ -50,7 +51,7 @@ func (p *PostgresBackend) CreatePricing(ctx context.Context, pricingDto types.Pr
 		strings.Join(argNames, ", "),
 	)
 
-	var createdId string
+	var createdId uuid.UUID
 	err := p.pool.QueryRow(ctx, query, args).Scan(&createdId)
 	if err != nil {
 		return nil, err
@@ -59,7 +60,7 @@ func (p *PostgresBackend) CreatePricing(ctx context.Context, pricingDto types.Pr
 	return p.FindPricingById(ctx, createdId)
 }
 
-func (p *PostgresBackend) DeletePricingById(ctx context.Context, id string) error {
+func (p *PostgresBackend) DeletePricingById(ctx context.Context, id uuid.UUID) error {
 	query := fmt.Sprintf(`DELETE FROM %s WHERE id = $1;`, PRICINGS_TABLE)
 
 	_, err := p.pool.Exec(ctx, query, id)

--- a/internal/storage/postgres/vault_token.go
+++ b/internal/storage/postgres/vault_token.go
@@ -1,0 +1,141 @@
+package postgres
+
+import (
+	"context"
+	"time"
+
+	"github.com/vultisig/verifier/internal/types"
+)
+
+func (p *PostgresBackend) CreateVaultToken(ctx context.Context, token types.VaultTokenCreate) (*types.VaultToken, error) {
+	query := `
+		INSERT INTO vault_tokens (public_key, token_id, issued_at, expires_at, is_revoked, last_used_at, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		RETURNING id, public_key, token_id, issued_at, expires_at, is_revoked, last_used_at, created_at, updated_at`
+
+	now := time.Now()
+	var vaultToken types.VaultToken
+	err := p.pool.QueryRow(ctx, query,
+		token.PublicKey,
+		token.TokenID,
+		now,
+		token.ExpiresAt,
+		false,
+		now,
+		now,
+		now,
+	).Scan(
+		&vaultToken.ID,
+		&vaultToken.PublicKey,
+		&vaultToken.TokenID,
+		&vaultToken.IssuedAt,
+		&vaultToken.ExpiresAt,
+		&vaultToken.IsRevoked,
+		&vaultToken.LastUsedAt,
+		&vaultToken.CreatedAt,
+		&vaultToken.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vaultToken, nil
+}
+
+func (p *PostgresBackend) GetVaultToken(ctx context.Context, tokenID string) (*types.VaultToken, error) {
+	query := `
+		SELECT id, public_key, token_id, issued_at, expires_at, is_revoked, last_used_at, created_at, updated_at
+		FROM vault_tokens
+		WHERE token_id = $1`
+
+	var vaultToken types.VaultToken
+	err := p.pool.QueryRow(ctx, query, tokenID).Scan(
+		&vaultToken.ID,
+		&vaultToken.PublicKey,
+		&vaultToken.TokenID,
+		&vaultToken.IssuedAt,
+		&vaultToken.ExpiresAt,
+		&vaultToken.IsRevoked,
+		&vaultToken.LastUsedAt,
+		&vaultToken.CreatedAt,
+		&vaultToken.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vaultToken, nil
+}
+
+func (p *PostgresBackend) RevokeVaultToken(ctx context.Context, tokenID string) error {
+	query := `
+		UPDATE vault_tokens
+		SET is_revoked = true, updated_at = $1
+		WHERE token_id = $2`
+
+	_, err := p.pool.Exec(ctx, query, time.Now(), tokenID)
+	return err
+}
+
+func (p *PostgresBackend) RevokeAllVaultTokens(ctx context.Context, publicKey string) error {
+	query := `
+		UPDATE vault_tokens
+		SET is_revoked = true, updated_at = $1
+		WHERE public_key = $2`
+
+	_, err := p.pool.Exec(ctx, query, time.Now(), publicKey)
+	return err
+}
+
+func (p *PostgresBackend) UpdateVaultTokenLastUsed(ctx context.Context, tokenID string) error {
+	query := `
+		UPDATE vault_tokens
+		SET last_used_at = $1, updated_at = $2
+		WHERE token_id = $3`
+
+	now := time.Now()
+	_, err := p.pool.Exec(ctx, query, now, now, tokenID)
+	return err
+}
+
+func (p *PostgresBackend) GetActiveVaultTokens(ctx context.Context, publicKey string) ([]types.VaultToken, error) {
+	query := `
+		SELECT id, public_key, token_id, issued_at, expires_at, is_revoked, last_used_at, created_at, updated_at
+		FROM vault_tokens
+		WHERE public_key = $1
+		AND is_revoked = false
+		AND expires_at > $2
+		ORDER BY issued_at DESC`
+
+	rows, err := p.pool.Query(ctx, query, publicKey, time.Now())
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var tokens []types.VaultToken
+	for rows.Next() {
+		var token types.VaultToken
+		err := rows.Scan(
+			&token.ID,
+			&token.PublicKey,
+			&token.TokenID,
+			&token.IssuedAt,
+			&token.ExpiresAt,
+			&token.IsRevoked,
+			&token.LastUsedAt,
+			&token.CreatedAt,
+			&token.UpdatedAt,
+		)
+		if err != nil {
+			return nil, err
+		}
+		tokens = append(tokens, token)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return tokens, nil
+}

--- a/internal/types/plugin.go
+++ b/internal/types/plugin.go
@@ -16,7 +16,7 @@ type Plugin struct {
 	Description    string          `json:"description" validate:"required"`
 	Metadata       json.RawMessage `json:"metadata" validate:"required"`
 	ServerEndpoint string          `json:"server_endpoint" validate:"required"`
-	PricingID      string          `json:"pricing_id" validate:"required"`
+	PricingID      uuid.UUID       `json:"pricing_id" validate:"required"`
 }
 
 type PlugisDto struct {
@@ -30,7 +30,7 @@ type PluginCreateDto struct {
 	Description    string          `json:"description" validate:"required"`
 	Metadata       json.RawMessage `json:"metadata" validate:"required"`
 	ServerEndpoint string          `json:"server_endpoint" validate:"required"`
-	PricingID      string          `json:"pricing_id" validate:"required"`
+	PricingID      uuid.UUID       `json:"pricing_id" validate:"required"`
 }
 
 // using references on struct fields allows us to process partially field DTOs
@@ -39,5 +39,5 @@ type PluginUpdateDto struct {
 	Description    string          `json:"description"`
 	Metadata       json.RawMessage `json:"metadata"`
 	ServerEndpoint string          `json:"server_endpoint"`
-	PricingID      string          `json:"pricing_id"`
+	PricingID      uuid.UUID       `json:"pricing_id"`
 }

--- a/internal/types/plugin.go
+++ b/internal/types/plugin.go
@@ -19,7 +19,7 @@ type Plugin struct {
 	PricingID      uuid.UUID       `json:"pricing_id" validate:"required"`
 }
 
-type PlugisDto struct {
+type PluginsDto struct {
 	Plugins    []Plugin `json:"plugins"`
 	TotalCount int      `json:"total_count"`
 }

--- a/internal/types/pricing.go
+++ b/internal/types/pricing.go
@@ -1,11 +1,13 @@
 package types
 
+import "github.com/google/uuid"
+
 type Pricing struct {
-	ID        string  `json:"id" validate:"required"`
-	Type      string  `json:"type" validate:"required,oneof=FREE SINGLE RECURRING PER_TX"`
-	Frequency *string `json:"frequency,omitempty" validate:"omitempty,oneof=ANNUAL MONTHLY WEEKLY"`
-	Amount    float64 `json:"amount" validate:"gte=0"`
-	Metric    string  `json:"metric" validate:"required,oneof=FIXED PERCENTAGE"`
+	ID        uuid.UUID `json:"id" validate:"required"`
+	Type      string    `json:"type" validate:"required,oneof=FREE SINGLE RECURRING PER_TX"`
+	Frequency *string   `json:"frequency,omitempty" validate:"omitempty,oneof=ANNUAL MONTHLY WEEKLY"`
+	Amount    float64   `json:"amount" validate:"gte=0"`
+	Metric    string    `json:"metric" validate:"required,oneof=FIXED PERCENTAGE"`
 }
 
 type PricingCreateDto struct {

--- a/internal/types/vault_token.go
+++ b/internal/types/vault_token.go
@@ -1,0 +1,23 @@
+package types
+
+import "time"
+
+// VaultToken represents a token stored in the database
+type VaultToken struct {
+	ID         string    `json:"id"`
+	PublicKey  string    `json:"public_key"`
+	TokenID    string    `json:"token_id"`
+	IssuedAt   time.Time `json:"issued_at"`
+	ExpiresAt  time.Time `json:"expires_at"`
+	IsRevoked  bool      `json:"is_revoked"`
+	LastUsedAt time.Time `json:"last_used_at"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+// VaultTokenCreate represents the data needed to create a new vault token
+type VaultTokenCreate struct {
+	PublicKey string    `json:"public_key"`
+	TokenID   string    `json:"token_id"`
+	ExpiresAt time.Time `json:"expires_at"`
+}

--- a/plugin/registry.go
+++ b/plugin/registry.go
@@ -1,0 +1,13 @@
+package plugin
+
+type PluginID string
+
+// Each plugin must reserve a unique ID.
+//
+// A plugin ID is comprised of a all-lowercase string, ending with 4 random hex digits.
+//
+// Example: vultisig-dca-00a1
+const (
+	PluginVultisigDCA_0000     PluginID = "vultisig-dca-0000"
+	PluginVultisigPayroll_0000 PluginID = "vultisig-payroll-0000"
+)

--- a/types/policy.go
+++ b/types/policy.go
@@ -9,8 +9,6 @@ import (
 type PluginPolicy struct {
 	ID            uuid.UUID       `json:"id" validate:"required"`
 	PublicKey     string          `json:"public_key" validate:"required"`
-	IsEcdsa       bool            `json:"is_ecdsa" validate:"required"`
-	ChainCodeHex  string          `json:"chain_code_hex" validate:"required"`
 	PluginID      uuid.UUID       `json:"plugin_id" validate:"required"`
 	PluginVersion string          `json:"plugin_version" validate:"required"`
 	PolicyVersion string          `json:"policy_version" validate:"required"`


### PR DESCRIPTION
This PR implements JWT-based authentication for vault operations and adds token management functionality.

Key Changes:
- Added VaultAuthMiddleware for JWT-based authentication
- Implemented token management endpoints:
  - DELETE /auth/tokens/:tokenId - Revoke specific token
  - DELETE /auth/tokens/all - Revoke all tokens
  - GET /auth/tokens - List active tokens
- Protected all vault endpoints with JWT authentication
- Added vault token storage methods:
  - CreateVaultToken
  - GetVaultToken
  - RevokeVaultToken
  - RevokeAllVaultTokens
  - UpdateVaultTokenLastUsed
  - GetActiveVaultTokens
- Created vault_token.go for token-related database operations

Security:
- All vault operations now require valid JWT token
- Token management allows granular control over access
- Tokens can be individually revoked or all tokens for a vault can be revoked


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added full token lifecycle management for vaults, including endpoints to create, refresh, revoke individual tokens, revoke all tokens, and list active tokens.
  - Introduced plugin management endpoints for listing, creating, updating, and deleting plugins.
  - Added robust Ethereum signature verification and address validation.
- **Improvements**
  - Enhanced authentication and error handling for all auth and vault endpoints.
  - Improved validation and type safety by switching to UUIDs for pricing and plugin identifiers.
  - Updated database schema and storage logic to support vault tokens and simplified policy storage.
- **Bug Fixes**
  - Fixed type inconsistencies and corrected struct/field names in plugin and pricing data models.
- **Chores**
  - Added and updated tests for new utility functions, token management, and signature verification.
  - Cleaned up unused imports and improved test skip messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->