### PR TITLE
 Make verifier host configurable in worker service

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -22,5 +22,11 @@
   "datadog": {
     "host": "localhost",
     "port": "8125"
+  },
+  "server": {
+    "host": "localhost",
+    "port": 8080,
+    "verifier_host": "localhost",
+    "jwt_secret": "your-jwt-secret"
   }
 }

--- a/config/config.go
+++ b/config/config.go
@@ -28,9 +28,10 @@ type Config struct {
 
 type VerifierConfig struct {
 	Server struct {
-		Host     string `mapstructure:"host" json:"host,omitempty"`
-		Port     int64  `mapstructure:"port" json:"port,omitempty"`
-		Database struct {
+		Host         string `mapstructure:"host" json:"host,omitempty"`
+		Port         int64  `mapstructure:"port" json:"port,omitempty"`
+		VerifierHost string `mapstructure:"verifier_host" json:"verifier_host,omitempty"`
+		Database     struct {
 			DSN string `mapstructure:"dsn" json:"dsn,omitempty"`
 		} `mapstructure:"database" json:"database,omitempty"`
 		JWTSecret string `mapstructure:"jwt_secret" json:"jwt_secret,omitempty"`

--- a/internal/service/worker.go
+++ b/internal/service/worker.go
@@ -23,7 +23,7 @@ import (
 )
 
 type WorkerService struct {
-	cfg          config.Config
+	cfg          config.VerifierConfig
 	verifierPort int64
 	redis        *storage.RedisStorage
 	logger       *logrus.Logger
@@ -37,7 +37,7 @@ type WorkerService struct {
 }
 
 // NewWorker creates a new worker service
-func NewWorker(cfg config.Config,
+func NewWorker(cfg config.VerifierConfig,
 	verifierPort int64,
 	queueClient *asynq.Client,
 	sdClient *statsd.Client, authService *AuthService,
@@ -73,8 +73,13 @@ func (s *WorkerService) initiateTxSignWithVerifier(ctx context.Context, signRequ
 		return err
 	}
 
+	verifierHost := s.cfg.Server.VerifierHost
+	if verifierHost == "" {
+		verifierHost = "localhost"
+	}
+
 	signResp, err := http.Post(
-		fmt.Sprintf("http://localhost:%d/signFromPlugin", s.verifierPort),
+		fmt.Sprintf("http://%s:%d/signFromPlugin", verifierHost, s.verifierPort),
 		"application/json",
 		bytes.NewBuffer(signBytes),
 	)


### PR DESCRIPTION
Currently, the worker service assumes the verifier is running on localhost. This change makes the verifier host configurable through the config file, allowing the verifier to be deployed on any machine.

Changes:
- Added VerifierHost field to Server config struct
- Updated config.example.json with verifier_host field
- Modified initiateTxSignWithVerifier to use configured host with localhost fallback

This change enables:
- Deploying verifier on different machines / on different networks
- Maintaining backward compatibility with localhost fallback


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new server configuration options, including customizable host, port, verifier host, and JWT secret in the configuration file.
  - The verifier host used for certain operations can now be set via configuration instead of being hardcoded.
- **Chores**
  - Updated configuration structure to support the new server and verifier host settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->