### PR TITLE
plugin/registry: introduce plugin registry with constants for DCA and payroll

### DIFF
--- a/plugin/registry.go
+++ b/plugin/registry.go
@@ -1,0 +1,13 @@
+package plugin
+
+type PluginID string
+
+// Each plugin must reserve a unique ID.
+//
+// A plugin ID is comprised of a all-lowercase string, ending with 4 random hex digits.
+//
+// Example: vultisig-dca-00a1
+const (
+	PluginVultisigDCA_0000     PluginID = "vultisig-dca-0000"
+	PluginVultisigPayroll_0000 PluginID = "vultisig-payroll-0000"
+)


### PR DESCRIPTION
Fixed #16

No functional changes, just introduces public constants for payroll and DCA

Subsequent PRs will use these in the policy refactors and recipe verification implementation flows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced unique identifiers for plugins, ensuring each plugin can be distinctly recognized within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->