### PR TITLE
verifier: adopt plugin registry and drop UUIDs as plugin identifiers

### DIFF
--- a/internal/api/plugin.go
+++ b/internal/api/plugin.go
@@ -4,10 +4,10 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 
 	"github.com/vultisig/verifier/internal/types"
+	ptypes "github.com/vultisig/verifier/types"
 )
 
 func (s *Server) GetPlugins(c echo.Context) error {
@@ -39,11 +39,8 @@ func (s *Server) GetPlugin(c echo.Context) error {
 	if pluginID == "" {
 		return c.JSON(http.StatusBadRequest, NewErrorResponse("failed to get plugin"))
 	}
-	uPluginID, err := uuid.Parse(pluginID)
-	if err != nil {
-		return c.JSON(http.StatusBadRequest, NewErrorResponse("failed to get plugin"))
-	}
-	plugin, err := s.db.FindPluginById(c.Request().Context(), uPluginID)
+
+	plugin, err := s.db.FindPluginById(c.Request().Context(), ptypes.PluginID(pluginID))
 	if err != nil {
 		s.logger.WithError(err).Error("Failed to get plugin")
 		return c.JSON(http.StatusInternalServerError, NewErrorResponse("failed to get plugin"))
@@ -85,11 +82,8 @@ func (s *Server) UpdatePlugin(c echo.Context) error {
 	if err := c.Validate(&plugin); err != nil {
 		return c.JSON(http.StatusBadRequest, NewErrorResponse(err.Error()))
 	}
-	uPluginID, err := uuid.Parse(pluginID)
-	if err != nil {
-		return c.JSON(http.StatusBadRequest, NewErrorResponse("invalid plugin id"))
-	}
-	updated, err := s.db.UpdatePlugin(c.Request().Context(), uPluginID, plugin)
+
+	updated, err := s.db.UpdatePlugin(c.Request().Context(), ptypes.PluginID(pluginID), plugin)
 	if err != nil {
 		s.logger.WithError(err).Error("Failed to update plugin")
 		return c.JSON(http.StatusInternalServerError, NewErrorResponse("failed to update plugin"))
@@ -103,11 +97,8 @@ func (s *Server) DeletePlugin(c echo.Context) error {
 	if pluginID == "" {
 		return c.JSON(http.StatusBadRequest, NewErrorResponse("plugin id is required"))
 	}
-	uPluginID, err := uuid.Parse(pluginID)
-	if err != nil {
-		return c.JSON(http.StatusBadRequest, NewErrorResponse("invalid plugin id"))
-	}
-	if err := s.db.DeletePluginById(c.Request().Context(), uPluginID); err != nil {
+
+	if err := s.db.DeletePluginById(c.Request().Context(), ptypes.PluginID(pluginID)); err != nil {
 		s.logger.WithError(err).Error("Failed to delete plugin")
 		return c.JSON(http.StatusInternalServerError, NewErrorResponse("failed to delete plugin"))
 	}

--- a/internal/api/policy.go
+++ b/internal/api/policy.go
@@ -177,7 +177,7 @@ func (s *Server) GetAllPluginPolicies(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, NewErrorResponse("invalid plugin type"))
 	}
 
-	policies, err := s.policyService.GetPluginPolicies(c.Request().Context(), publicKey, pluginType)
+	policies, err := s.policyService.GetPluginPolicies(c.Request().Context(), types.PluginID(pluginType), publicKey)
 	if err != nil {
 		s.logger.Errorf("failed to get policies for public_key: %s,plugin_type: %s,err: %s", publicKey, pluginType, err)
 		return c.JSON(http.StatusInternalServerError, NewErrorResponse("failed to get policies"))

--- a/internal/service/auth_test.go
+++ b/internal/service/auth_test.go
@@ -144,12 +144,12 @@ func (m *MockDatabaseStorage) CreateTransactionHistoryTx(ctx context.Context, db
 	return args.Get(0).(uuid.UUID), args.Error(1)
 }
 
-func (m *MockDatabaseStorage) DeletePluginById(ctx context.Context, id uuid.UUID) error {
+func (m *MockDatabaseStorage) DeletePluginById(ctx context.Context, id types.PluginID) error {
 	args := m.Called(ctx, id)
 	return args.Error(0)
 }
 
-func (m *MockDatabaseStorage) FindPluginById(ctx context.Context, id uuid.UUID) (*itypes.Plugin, error) {
+func (m *MockDatabaseStorage) FindPluginById(ctx context.Context, id types.PluginID) (*itypes.Plugin, error) {
 	args := m.Called(ctx, id)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
@@ -162,8 +162,8 @@ func (m *MockDatabaseStorage) FindPlugins(ctx context.Context, take int, skip in
 	return args.Get(0).(itypes.PluginsDto), args.Error(1)
 }
 
-func (m *MockDatabaseStorage) UpdatePlugin(ctx context.Context, id uuid.UUID, updates itypes.PluginUpdateDto) (*itypes.Plugin, error) {
-	args := m.Called(ctx, id, updates)
+func (m *MockDatabaseStorage) UpdatePlugin(ctx context.Context, pluginID types.PluginID, updates itypes.PluginUpdateDto) (*itypes.Plugin, error) {
+	args := m.Called(ctx, pluginID, updates)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
@@ -178,8 +178,8 @@ func (m *MockDatabaseStorage) GetPluginPolicy(ctx context.Context, id uuid.UUID)
 	return args.Get(0).(types.PluginPolicy), args.Error(1)
 }
 
-func (m *MockDatabaseStorage) GetAllPluginPolicies(ctx context.Context, publicKey string, pluginType string) ([]types.PluginPolicy, error) {
-	args := m.Called(ctx, publicKey, pluginType)
+func (m *MockDatabaseStorage) GetAllPluginPolicies(ctx context.Context, publicKey string, pluginID types.PluginID) ([]types.PluginPolicy, error) {
+	args := m.Called(ctx, publicKey, pluginID)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}

--- a/internal/service/policy.go
+++ b/internal/service/policy.go
@@ -20,8 +20,8 @@ import (
 type Policy interface {
 	CreatePolicy(ctx context.Context, policy types.PluginPolicy) (*types.PluginPolicy, error)
 	UpdatePolicy(ctx context.Context, policy types.PluginPolicy) (*types.PluginPolicy, error)
-	DeletePolicy(ctx context.Context, policyID, pluginID uuid.UUID, signature string) error
-	GetPluginPolicies(ctx context.Context, pluginType, publicKey string) ([]types.PluginPolicy, error)
+	DeletePolicy(ctx context.Context, policyID uuid.UUID, pluginID types.PluginID, signature string) error
+	GetPluginPolicies(ctx context.Context, pluginID types.PluginID, publicKey string) ([]types.PluginPolicy, error)
 	GetPluginPolicy(ctx context.Context, policyID uuid.UUID) (types.PluginPolicy, error)
 	GetPluginPolicyTransactionHistory(ctx context.Context, policyID uuid.UUID) ([]itypes.TransactionHistory, error)
 }
@@ -141,7 +141,7 @@ func (s *PolicyService) handleRollback(tx pgx.Tx, ctx context.Context) {
 	}
 }
 
-func (s *PolicyService) DeletePolicy(ctx context.Context, policyID uuid.UUID, pluginID uuid.UUID, signature string) error {
+func (s *PolicyService) DeletePolicy(ctx context.Context, policyID uuid.UUID, pluginID types.PluginID, signature string) error {
 	tx, err := s.db.Pool().Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
@@ -176,8 +176,8 @@ func (s *PolicyService) DeletePolicy(ctx context.Context, policyID uuid.UUID, pl
 	return nil
 }
 
-func (s *PolicyService) GetPluginPolicies(ctx context.Context, pluginType, publicKey string) ([]types.PluginPolicy, error) {
-	policies, err := s.db.GetAllPluginPolicies(ctx, pluginType, publicKey)
+func (s *PolicyService) GetPluginPolicies(ctx context.Context, pluginID types.PluginID, publicKey string) ([]types.PluginPolicy, error) {
+	policies, err := s.db.GetAllPluginPolicies(ctx, publicKey, pluginID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get policies: %w", err)
 	}

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -26,7 +26,7 @@ type DatabaseStorage interface {
 	GetActiveVaultTokens(ctx context.Context, publicKey string) ([]itypes.VaultToken, error)
 
 	GetPluginPolicy(ctx context.Context, id uuid.UUID) (types.PluginPolicy, error)
-	GetAllPluginPolicies(ctx context.Context, publicKey string, pluginType string) ([]types.PluginPolicy, error)
+	GetAllPluginPolicies(ctx context.Context, publicKey string, pluginID types.PluginID) ([]types.PluginPolicy, error)
 	DeletePluginPolicyTx(ctx context.Context, dbTx pgx.Tx, id uuid.UUID) error
 	InsertPluginPolicyTx(ctx context.Context, dbTx pgx.Tx, policy types.PluginPolicy) (*types.PluginPolicy, error)
 	UpdatePluginPolicyTx(ctx context.Context, dbTx pgx.Tx, policy types.PluginPolicy) (*types.PluginPolicy, error)
@@ -44,10 +44,10 @@ type DatabaseStorage interface {
 	GetTransactionByHash(ctx context.Context, txHash string) (*itypes.TransactionHistory, error)
 
 	FindPlugins(ctx context.Context, take int, skip int, sort string) (itypes.PluginsDto, error)
-	FindPluginById(ctx context.Context, id uuid.UUID) (*itypes.Plugin, error)
+	FindPluginById(ctx context.Context, id types.PluginID) (*itypes.Plugin, error)
 	CreatePlugin(ctx context.Context, pluginDto itypes.PluginCreateDto) (*itypes.Plugin, error)
-	UpdatePlugin(ctx context.Context, id uuid.UUID, updates itypes.PluginUpdateDto) (*itypes.Plugin, error)
-	DeletePluginById(ctx context.Context, id uuid.UUID) error
+	UpdatePlugin(ctx context.Context, id types.PluginID, updates itypes.PluginUpdateDto) (*itypes.Plugin, error)
+	DeletePluginById(ctx context.Context, id types.PluginID) error
 
 	AddPluginPolicySync(ctx context.Context, dbTx pgx.Tx, policy itypes.PluginPolicySync) error
 	GetPluginPolicySync(ctx context.Context, id uuid.UUID) (*itypes.PluginPolicySync, error)

--- a/internal/storage/postgres/db_test.go
+++ b/internal/storage/postgres/db_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	itypes "github.com/vultisig/verifier/internal/types"
+	ptypes "github.com/vultisig/verifier/types"
 )
 
 func TestAddPluginPolicySync(t *testing.T) {
@@ -21,7 +22,7 @@ func TestAddPluginPolicySync(t *testing.T) {
 	err = db.AddPluginPolicySync(ctx, tx, itypes.PluginPolicySync{
 		ID:         syncID,
 		PolicyID:   uuid.New(),
-		PluginID:   uuid.New(),
+		PluginID:   ptypes.PluginVultisigDCA_0000,
 		SyncType:   itypes.AddPolicy,
 		Signature:  "signature",
 		Status:     itypes.NotSynced,

--- a/internal/storage/postgres/migrations/20250511222334_plugin_id_migration_to_enum.sql
+++ b/internal/storage/postgres/migrations/20250511222334_plugin_id_migration_to_enum.sql
@@ -1,0 +1,68 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TYPE plugin_id AS ENUM (
+    'vultisig-dca-0000',
+    'vultisig-payroll-0000'
+);
+
+ALTER TABLE plugin_policies
+    DROP COLUMN plugin_id;
+
+ALTER TABLE plugin_policies
+    ADD COLUMN plugin_id plugin_id;
+
+UPDATE plugin_policies
+    SET plugin_id = 'vultisig-dca-0000'
+    WHERE plugin_type = 'dca';
+
+UPDATE plugin_policies
+    SET plugin_id = 'vultisig-payroll-0000'
+    WHERE plugin_type = 'payroll';
+
+ALTER TABLE plugin_policies
+    ALTER COLUMN plugin_id SET NOT NULL;
+
+ALTER TABLE plugin_policies
+    DROP COLUMN plugin_type;
+
+DROP TYPE plugin_type;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+CREATE TYPE plugin_type AS ENUM (
+    'dca',
+    'payroll'
+);
+
+ALTER TABLE plugin_policies
+    ADD COLUMN plugin_type plugin_type;
+
+UPDATE plugin_policies
+    SET plugin_type = 'dca'
+    WHERE plugin_id = 'vultisig-dca-0000';
+
+UPDATE plugin_policies
+    SET plugin_type = 'payroll'
+    WHERE plugin_id = 'vultisig-payroll-0000';
+
+ALTER TABLE plugin_policies
+    DROP COLUMN plugin_id;
+
+ALTER TABLE plugin_policies
+    ADD COLUMN plugin_id TEXT;
+
+UPDATE plugin_policies
+    SET plugin_id = 'vultisig-dca-0000'
+    WHERE plugin_type = 'dca';
+
+UPDATE plugin_policies
+    SET plugin_id = 'vultisig-payroll-0000'
+    WHERE plugin_type = 'payroll';
+
+ALTER TABLE plugin_policies
+    ALTER COLUMN plugin_id SET NOT NULL;
+
+DROP TYPE plugin_id;
+-- +goose StatementEnd

--- a/internal/storage/postgres/plugin.go
+++ b/internal/storage/postgres/plugin.go
@@ -7,16 +7,16 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 
 	"github.com/vultisig/verifier/common"
 	"github.com/vultisig/verifier/internal/types"
+	ptypes "github.com/vultisig/verifier/types"
 )
 
 const PLUGINS_TABLE = "plugins"
 
-func (p *PostgresBackend) FindPluginById(ctx context.Context, id uuid.UUID) (*types.Plugin, error) {
+func (p *PostgresBackend) FindPluginById(ctx context.Context, id ptypes.PluginID) (*types.Plugin, error) {
 	query := fmt.Sprintf(`SELECT * FROM %s WHERE id = $1 LIMIT 1;`, PLUGINS_TABLE)
 
 	rows, err := p.pool.Query(ctx, query, id)
@@ -110,7 +110,7 @@ func (p *PostgresBackend) CreatePlugin(ctx context.Context, pluginDto types.Plug
 		"PricingID":      pluginDto.PricingID,
 	}
 
-	var createdId uuid.UUID
+	var createdId ptypes.PluginID
 	err := p.pool.QueryRow(ctx, query, args).Scan(&createdId)
 	if err != nil {
 		return nil, err
@@ -119,7 +119,7 @@ func (p *PostgresBackend) CreatePlugin(ctx context.Context, pluginDto types.Plug
 	return p.FindPluginById(ctx, createdId)
 }
 
-func (p *PostgresBackend) UpdatePlugin(ctx context.Context, id uuid.UUID, updates types.PluginUpdateDto) (*types.Plugin, error) {
+func (p *PostgresBackend) UpdatePlugin(ctx context.Context, id ptypes.PluginID, updates types.PluginUpdateDto) (*types.Plugin, error) {
 	t := reflect.TypeOf(updates)
 	v := reflect.ValueOf(updates)
 	numFields := t.NumField()
@@ -170,7 +170,7 @@ func (p *PostgresBackend) UpdatePlugin(ctx context.Context, id uuid.UUID, update
 	return p.FindPluginById(ctx, id)
 }
 
-func (p *PostgresBackend) DeletePluginById(ctx context.Context, id uuid.UUID) error {
+func (p *PostgresBackend) DeletePluginById(ctx context.Context, id ptypes.PluginID) error {
 	query := fmt.Sprintf(`DELETE FROM %s WHERE id = $1;`, PLUGINS_TABLE)
 
 	_, err := p.pool.Exec(ctx, query, id)

--- a/internal/storage/postgres/policy.go
+++ b/internal/storage/postgres/policy.go
@@ -51,11 +51,7 @@ func (p *PostgresBackend) GetAllPluginPolicies(ctx context.Context, publicKey st
 	}
 
 	query := `
-<<<<<<< HEAD
-  	SELECT id, public_key,  plugin_id, plugin_version, policy_version, plugin_type, signature, active, policy 
-=======
-  	SELECT id, public_key, is_ecdsa, chain_code_hex, plugin_id, plugin_version, policy_version, signature, active, policy 
->>>>>>> 37d94f9 (verifier: adopt plugin ID enum/const instead of UUID)
+  	SELECT id, public_key, plugin_id, plugin_version, policy_version, signature, active, policy 
 		FROM plugin_policies
 		WHERE public_key = $1
 		AND plugin_id = $2`

--- a/internal/storage/postgres/policy.go
+++ b/internal/storage/postgres/policy.go
@@ -91,15 +91,9 @@ func (p *PostgresBackend) InsertPluginPolicyTx(ctx context.Context, dbTx pgx.Tx,
 
 	query := `
   	INSERT INTO plugin_policies (
-<<<<<<< HEAD
-      id, public_key, plugin_id, plugin_version, policy_version, plugin_type, signature, active, policy
-    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-    RETURNING id, public_key, plugin_id, plugin_version, policy_version, plugin_type, signature, active, policy
-=======
-      id, public_key, is_ecdsa, chain_code_hex, plugin_id, plugin_version, policy_version, signature, active, policy
-    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-    RETURNING id, public_key, is_ecdsa, chain_code_hex, plugin_id, plugin_version, policy_version, signature, active, policy
->>>>>>> 37d94f9 (verifier: adopt plugin ID enum/const instead of UUID)
+      id, public_key, plugin_id, plugin_version, policy_version, signature, active, policy
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+    RETURNING id, public_key, plugin_id, plugin_version, policy_version, signature, active, policy
 	`
 
 	var insertedPolicy types.PluginPolicy

--- a/internal/types/policy_sync.go
+++ b/internal/types/policy_sync.go
@@ -1,6 +1,9 @@
 package types
 
-import "github.com/google/uuid"
+import (
+	"github.com/google/uuid"
+	ptypes "github.com/vultisig/verifier/types"
+)
 
 type PolicySyncStatus int
 type PolicySyncType int
@@ -20,7 +23,7 @@ const (
 type PluginPolicySync struct {
 	ID         uuid.UUID        `json:"id" validate:"required"`
 	PolicyID   uuid.UUID        `json:"policy_id" validate:"required"`
-	PluginID   uuid.UUID        `json:"plugin_id" validate:"required"`
+	PluginID   ptypes.PluginID  `json:"plugin_id" validate:"required"`
 	Signature  string           `json:"signature" validate:"required"`
 	SyncType   PolicySyncType   `json:"sync_type" validate:"required"`
 	Status     PolicySyncStatus `json:"status" validate:"required"`

--- a/types/policy.go
+++ b/types/policy.go
@@ -9,10 +9,9 @@ import (
 type PluginPolicy struct {
 	ID            uuid.UUID       `json:"id" validate:"required"`
 	PublicKey     string          `json:"public_key" validate:"required"`
-	PluginID      uuid.UUID       `json:"plugin_id" validate:"required"`
+	PluginID      PluginID        `json:"plugin_id" validate:"required"`
 	PluginVersion string          `json:"plugin_version" validate:"required"`
 	PolicyVersion string          `json:"policy_version" validate:"required"`
-	PluginType    string          `json:"plugin_type" validate:"required"`
 	Signature     string          `json:"signature" validate:"required"`
 	Policy        json.RawMessage `json:"policy" validate:"required"`
 	Active        bool            `json:"active" validate:"required"`

--- a/types/registry.go
+++ b/types/registry.go
@@ -1,4 +1,4 @@
-package plugin
+package types
 
 type PluginID string
 
@@ -11,3 +11,7 @@ const (
 	PluginVultisigDCA_0000     PluginID = "vultisig-dca-0000"
 	PluginVultisigPayroll_0000 PluginID = "vultisig-payroll-0000"
 )
+
+func (p PluginID) String() string {
+	return string(p)
+}


### PR DESCRIPTION
Fixed 42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated plugin identification throughout the system to use a new, domain-specific plugin ID type instead of generic UUIDs.
  - Removed the use of plugin type strings in favor of the new plugin ID for policy and plugin operations.
  - Adjusted database schema and migrations to support the new plugin ID format and removed legacy plugin type columns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->