### PR TITLE
storage/migrations: fix non-nullable category_id on column creation

### DIFF
--- a/internal/storage/postgres/migrations/20250409111539_categories.sql
+++ b/internal/storage/postgres/migrations/20250409111539_categories.sql
@@ -6,11 +6,18 @@ CREATE TABLE categories (
 );
 
 ALTER TABLE plugins
-    ADD COLUMN category_id UUID NOT NULL,
+    ADD COLUMN category_id UUID,
     ADD CONSTRAINT fk_plugins_category FOREIGN KEY (category_id) REFERENCES categories(id);
 
 INSERT INTO categories (name)
     VALUES ('AI Agent'), ('Plugin');
+
+UPDATE plugins
+    SET category_id = (SELECT id FROM categories WHERE name = 'Plugin');
+
+ALTER TABLE plugins
+    ALTER COLUMN category_id SET NOT NULL;
+    
 -- +goose StatementEnd
 
 -- +goose Down


### PR DESCRIPTION
The deployment fails presently as one of the migrations attempts to create a new non-nullable column when there are existing records

```
May 23 07:48:12 beta-verification-server verifier[2134299]: time="2025-05-23T07:48:12Z" level=fatal msg="Failed to connect to database: failed to migrate database: failed to run goose up: ERROR 20250409111539_categories.sql: failed to run SQL migration: failed to execute SQL query \"CREATE TABLE categories (\\n    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),\\n    name VARCHAR(255) NOT NULL\\n);\\nALTER TABLE plugins\\n    ADD COLUMN category_id UUID NOT NULL,\\n    ADD CONSTRAINT fk_plugins_category FOREIGN KEY (category_id) REFERENCES categories(id);\\nINSERT INTO categories (name)\\n    VALUES ('AI Agent'), ('Plugin');\": ERROR: column \"category_id\" of relation \"plugins\" contains null values (SQLSTATE 23502)"
```

This PR fixes that by creating the column as nullable first, then backfilling the category ID for existing records, and changing it to non-nullable after that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved database migration process to ensure all plugins are correctly assigned a category before enforcing stricter data requirements. No visible changes to the user interface or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->