### PR TITLE
api: refactor KeysignRequest for better plugin integration

### DIFF
--- a/types/keysign.go
+++ b/types/keysign.go
@@ -14,12 +14,13 @@ const (
 )
 
 type KeysignRequest struct {
-	PublicKey string           `json:"public_key"` // public key, used to identify the backup file
-	Messages  []KeysignMessage `json:"messages"`
-	SessionID string           `json:"session"`   // Session ID , it should be an UUID
-	Parties   []string         `json:"parties"`   // parties to join the session
-	PluginID  string           `json:"plugin_id"` // plugin id
-	PolicyID  uuid.UUID        `json:"policy_id"` // policy id
+	PublicKey        string           `json:"public_key"` // public key, used to identify the backup file
+	Messages         []KeysignMessage `json:"messages"`
+	SessionID        string           `json:"session"`            // Session ID , it should be an UUID
+	HexEncryptionKey string           `json:"hex_encryption_key"` // Hex encryption key, used to encrypt the keysign messages
+	Parties          []string         `json:"parties"`            // parties to join the session
+	PluginID         string           `json:"plugin_id"`          // plugin id
+	PolicyID         uuid.UUID        `json:"policy_id"`          // policy id
 }
 
 type KeysignMessage struct {
@@ -39,6 +40,9 @@ func (r KeysignRequest) IsValid() error {
 	}
 	if r.SessionID == "" {
 		return errors.New("invalid session")
+	}
+	if r.HexEncryptionKey == "" {
+		return errors.New("invalid hex encryption key")
 	}
 
 	return nil

--- a/types/keysign.go
+++ b/types/keysign.go
@@ -2,17 +2,31 @@ package types
 
 import (
 	"errors"
+
+	"github.com/google/uuid"
+)
+
+type HashFunction string
+
+const (
+	HashFunction_SHA256 HashFunction = "SHA256"
 )
 
 type KeysignRequest struct {
-	PublicKey        string   `json:"public_key"`         // public key, used to identify the backup file
-	Messages         []string `json:"messages"`           // Messages need to be signed
-	SessionID        string   `json:"session"`            // Session ID , it should be an UUID
-	HexEncryptionKey string   `json:"hex_encryption_key"` // Hex encryption key, used to encrypt the keysign messages
-	DerivePath       string   `json:"derive_path"`        // Derive Path
-	IsECDSA          bool     `json:"is_ecdsa"`           // indicate use ECDSA or EDDSA key to sign the messages
-	Parties          []string `json:"parties"`            // parties to join the session
-	PluginID         string   `json:"plugin_id"`          // plugin id
+	PublicKey string           `json:"public_key"` // public key, used to identify the backup file
+	Messages  []KeysignMessage `json:"messages"`
+	SessionID string           `json:"session"`   // Session ID , it should be an UUID
+	Parties   []string         `json:"parties"`   // parties to join the session
+	PluginID  string           `json:"plugin_id"` // plugin id
+	PolicyID  uuid.UUID        `json:"policy_id"` // policy id
+}
+
+type KeysignMessage struct {
+	Message      string       `json:"message"`
+	Hash         string       `json:"hash"`
+	HashFunction HashFunction `json:"hash_function"`
+	DerivePath   string       `json:"derive_path"`
+	IsECDSA      bool         `json:"is_ecdsa"`
 }
 
 // IsValid checks if the keysign request is valid
@@ -25,12 +39,6 @@ func (r KeysignRequest) IsValid() error {
 	}
 	if r.SessionID == "" {
 		return errors.New("invalid session")
-	}
-	if r.HexEncryptionKey == "" {
-		return errors.New("invalid hex encryption key")
-	}
-	if r.DerivePath == "" {
-		return errors.New("invalid derive path")
 	}
 
 	return nil

--- a/types/keysign.go
+++ b/types/keysign.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/google/uuid"
+	"github.com/vultisig/verifier/common"
 )
 
 type HashFunction string
@@ -25,8 +26,7 @@ type KeysignMessage struct {
 	Message      string       `json:"message"`
 	Hash         string       `json:"hash"`
 	HashFunction HashFunction `json:"hash_function"`
-	DerivePath   string       `json:"derive_path"`
-	IsECDSA      bool         `json:"is_ecdsa"`
+	Chain        common.Chain `json:"chain"`
 }
 
 // IsValid checks if the keysign request is valid

--- a/vault/keysign.go
+++ b/vault/keysign.go
@@ -79,7 +79,7 @@ func (t *DKLSTssService) ProcessDKLSKeysign(req types.KeysignRequest) (map[strin
 			publicKey = localStateAccessor.Vault.PublicKeyEddsa
 		}
 
-		sig, err := t.keysignWithRetry(req.SessionID, t.cfg.EncryptionSecret, publicKey, msg.Chain.IsEdDSA(), msg.Hash, msg.Chain.GetDerivePath(), localPartyID, partiesJoined)
+		sig, err := t.keysignWithRetry(req.SessionID, req.HexEncryptionKey, publicKey, msg.Chain.IsEdDSA(), msg.Hash, msg.Chain.GetDerivePath(), localPartyID, partiesJoined)
 		if err != nil {
 			return result, fmt.Errorf("failed to keysign: %w", err)
 		}

--- a/vault/keysign.go
+++ b/vault/keysign.go
@@ -72,13 +72,14 @@ func (t *DKLSTssService) ProcessDKLSKeysign(req types.KeysignRequest) (map[strin
 	// start to do keysign
 	for _, msg := range req.Messages {
 		var publicKey string
-		if msg.IsECDSA {
+
+		if msg.Chain.IsEdDSA() {
 			publicKey = localStateAccessor.Vault.PublicKeyEcdsa
 		} else {
 			publicKey = localStateAccessor.Vault.PublicKeyEddsa
 		}
 
-		sig, err := t.keysignWithRetry(req.SessionID, t.cfg.EncryptionSecret, publicKey, !msg.IsECDSA, msg.Hash, msg.DerivePath, localPartyID, partiesJoined)
+		sig, err := t.keysignWithRetry(req.SessionID, t.cfg.EncryptionSecret, publicKey, msg.Chain.IsEdDSA(), msg.Hash, msg.Chain.GetDerivePath(), localPartyID, partiesJoined)
 		if err != nil {
 			return result, fmt.Errorf("failed to keysign: %w", err)
 		}

--- a/vault/keysign.go
+++ b/vault/keysign.go
@@ -78,7 +78,7 @@ func (t *DKLSTssService) ProcessDKLSKeysign(req types.KeysignRequest) (map[strin
 			publicKey = localStateAccessor.Vault.PublicKeyEddsa
 		}
 
-		sig, err := t.keysignWithRetry(req.SessionID, t.cfg.EncryptionSecret, publicKey, msg.IsECDSA, msg.Hash, msg.DerivePath, localPartyID, partiesJoined)
+		sig, err := t.keysignWithRetry(req.SessionID, t.cfg.EncryptionSecret, publicKey, !msg.IsECDSA, msg.Hash, msg.DerivePath, localPartyID, partiesJoined)
 		if err != nil {
 			return result, fmt.Errorf("failed to keysign: %w", err)
 		}

--- a/vault/keysign.go
+++ b/vault/keysign.go
@@ -68,20 +68,24 @@ func (t *DKLSTssService) ProcessDKLSKeysign(req types.KeysignRequest) (map[strin
 	if err != nil {
 		return nil, fmt.Errorf("failed to wait for session start: %w", err)
 	}
-	publicKey := req.PublicKey
-	if !req.IsECDSA {
-		publicKey = localStateAccessor.Vault.PublicKeyEddsa
-	}
+
 	// start to do keysign
 	for _, msg := range req.Messages {
-		sig, err := t.keysignWithRetry(req.SessionID, req.HexEncryptionKey, publicKey, !req.IsECDSA, msg, req.DerivePath, localPartyID, partiesJoined)
+		var publicKey string
+		if msg.IsECDSA {
+			publicKey = localStateAccessor.Vault.PublicKeyEcdsa
+		} else {
+			publicKey = localStateAccessor.Vault.PublicKeyEddsa
+		}
+
+		sig, err := t.keysignWithRetry(req.SessionID, t.cfg.EncryptionSecret, publicKey, msg.IsECDSA, msg.Hash, msg.DerivePath, localPartyID, partiesJoined)
 		if err != nil {
 			return result, fmt.Errorf("failed to keysign: %w", err)
 		}
 		if sig == nil {
 			return result, fmt.Errorf("failed to keysign: signature is nil")
 		}
-		result[msg] = *sig
+		result[msg.Hash] = *sig
 	}
 	if err := relayClient.CompleteSession(req.SessionID, localPartyID); err != nil {
 		t.logger.WithFields(logrus.Fields{

--- a/vault/service.go
+++ b/vault/service.go
@@ -136,11 +136,11 @@ func (s *ManagementService) HandleKeySignDKLS(ctx context.Context, t *asynq.Task
 	defer s.measureTime("worker.vault.sign.latency", time.Now(), []string{})
 	s.incCounter("worker.vault.sign", []string{})
 	s.logger.WithFields(logrus.Fields{
-		"PublicKey":  p.PublicKey,
-		"session":    p.SessionID,
-		"Messages":   p.Messages,
-		"DerivePath": p.DerivePath,
-		"IsECDSA":    p.IsECDSA,
+		"PublicKey": p.PublicKey,
+		"session":   p.SessionID,
+		"Messages":  len(p.Messages),
+		"PluginID":  p.PluginID,
+		"PolicyID":  p.PolicyID,
 	}).Info("joining keysign")
 
 	dklsService, err := NewDKLSTssService(s.cfg, s.vaultStorage, s.queueClient)


### PR DESCRIPTION
Refactors the keysign request to support:

1. Multiple chains for signing (each message gets its own derivation path and ECDSA flag)
2. Top-level support for policy and plugin IDs

This is just a worker + type refactor - it doesn't wire it up to the API yet (that's still using PluginKeysignRequest) - I will do the API update with a paired PR on plugin and verifier, I need the type updated first so I can import it on the plugin side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced key signing requests to support multiple message types and per-message cryptographic settings.
	- Added support for policy identification within key signing requests.

- **Improvements**
	- Improved logging to include plugin and policy identifiers, and display the number of messages instead of raw message content.
	- Key signing now dynamically selects the appropriate public key for each message, increasing flexibility and accuracy.

- **Bug Fixes**
	- Corrected signature association to use message hashes, ensuring accurate tracking of signed messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->