### PR TITLE
auth: fix auth and vault token schema

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-go/statsd"
@@ -382,7 +383,7 @@ func (s *Server) Auth(c echo.Context) error {
 	}
 
 	// Decode signature from hex (remove 0x prefix first)
-	sigBytes, err := hex.DecodeString(req.Signature)
+	sigBytes, err := hex.DecodeString(strings.TrimPrefix(req.Signature, "0x"))
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, NewErrorResponse("Invalid signature format"))
 	}

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -137,7 +137,7 @@ func (a *AuthService) ValidateToken(ctx context.Context, tokenStr string) (*Clai
 		return nil, errors.New("token not found in database")
 	}
 
-	if dbToken.IsRevoked {
+	if dbToken.RevokedAt.Before(time.Now()) {
 		return nil, errors.New("token has been revoked")
 	}
 

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -137,7 +137,7 @@ func (a *AuthService) ValidateToken(ctx context.Context, tokenStr string) (*Clai
 		return nil, errors.New("token not found in database")
 	}
 
-	if dbToken != nil && dbToken.RevokedAt.Before(time.Now()) {
+	if !dbToken.RevokedAt.IsZero() && dbToken.RevokedAt.Before(time.Now()) {
 		return nil, errors.New("token has been revoked")
 	}
 

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -137,7 +137,7 @@ func (a *AuthService) ValidateToken(ctx context.Context, tokenStr string) (*Clai
 		return nil, errors.New("token not found in database")
 	}
 
-	if dbToken.RevokedAt.Before(time.Now()) {
+	if dbToken != nil && dbToken.RevokedAt.Before(time.Now()) {
 		return nil, errors.New("token has been revoked")
 	}
 

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -137,7 +137,7 @@ func (a *AuthService) ValidateToken(ctx context.Context, tokenStr string) (*Clai
 		return nil, errors.New("token not found in database")
 	}
 
-	if !dbToken.RevokedAt.IsZero() && dbToken.RevokedAt.Before(time.Now()) {
+	if dbToken.IsRevoked() {
 		return nil, errors.New("token has been revoked")
 	}
 

--- a/internal/service/auth_test.go
+++ b/internal/service/auth_test.go
@@ -369,12 +369,10 @@ func TestValidateToken(t *testing.T) {
 			setupToken: func() string {
 				mockDB := new(MockDatabaseStorage)
 				mockDB.On("CreateVaultToken", mock.Anything, mock.Anything).Return(&itypes.VaultToken{
-					TokenID:   "valid-token",
-					IsRevoked: false,
+					TokenID: "valid-token",
 				}, nil)
 				mockDB.On("GetVaultToken", mock.Anything, mock.Anything).Return(&itypes.VaultToken{
-					TokenID:   "valid-token",
-					IsRevoked: false,
+					TokenID: "valid-token",
 				}, nil)
 				mockDB.On("UpdateVaultTokenLastUsed", mock.Anything, mock.Anything).Return(nil)
 
@@ -447,8 +445,7 @@ func TestValidateToken(t *testing.T) {
 			tokenString := tc.setupToken()
 			mockDB := new(MockDatabaseStorage)
 			mockDB.On("GetVaultToken", mock.Anything, mock.Anything).Return(&itypes.VaultToken{
-				TokenID:   "valid-token",
-				IsRevoked: false,
+				TokenID: "valid-token",
 			}, nil)
 			mockDB.On("UpdateVaultTokenLastUsed", mock.Anything, mock.Anything).Return(nil)
 
@@ -485,13 +482,11 @@ func TestRefreshToken(t *testing.T) {
 					Return(&itypes.VaultToken{
 						TokenID:   tokenID,
 						PublicKey: testPublicKey,
-						IsRevoked: false,
 					}, nil)
 				mockDB.On("GetVaultToken", mock.Anything, tokenID).
 					Return(&itypes.VaultToken{
 						TokenID:   tokenID,
 						PublicKey: testPublicKey,
-						IsRevoked: false,
 					}, nil)
 				mockDB.On("UpdateVaultTokenLastUsed", mock.Anything, tokenID).Return(nil)
 				mockDB.On("RevokeVaultToken", mock.Anything, tokenID).Return(nil)
@@ -537,13 +532,11 @@ func TestRefreshToken(t *testing.T) {
 					Return(&itypes.VaultToken{
 						TokenID:   tokenID,
 						PublicKey: testPublicKey,
-						IsRevoked: false,
 					}, nil)
 				mockDB.On("GetVaultToken", mock.Anything, mock.Anything).
 					Return(&itypes.VaultToken{
 						TokenID:   tokenID,
 						PublicKey: testPublicKey,
-						IsRevoked: false,
 					}, nil)
 				mockDB.On("UpdateVaultTokenLastUsed", mock.Anything, mock.Anything).Return(nil)
 				mockDB.On("RevokeVaultToken", mock.Anything, mock.Anything).Return(nil)

--- a/internal/storage/postgres/migrations/verifier/20250529075930_drop_name_permissions_from_vault_tokens.sql
+++ b/internal/storage/postgres/migrations/verifier/20250529075930_drop_name_permissions_from_vault_tokens.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE vault_tokens DROP COLUMN name;
+ALTER TABLE vault_tokens DROP COLUMN permissions;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ROLLBACK;
+-- +goose StatementEnd

--- a/internal/storage/postgres/migrations/verifier/20250529080425_add_updated_at_to_vault_tokens.sql
+++ b/internal/storage/postgres/migrations/verifier/20250529080425_add_updated_at_to_vault_tokens.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE vault_tokens ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ROLLBACK;
+-- +goose StatementEnd

--- a/internal/types/vault_token.go
+++ b/internal/types/vault_token.go
@@ -5,14 +5,14 @@ import "time"
 // VaultToken represents a token stored in the database
 type VaultToken struct {
 	ID         string    `json:"id"`
-	PublicKey  string    `json:"public_key"`
 	TokenID    string    `json:"token_id"`
-	IssuedAt   time.Time `json:"issued_at"`
+	PublicKey  string    `json:"public_key"`
 	ExpiresAt  time.Time `json:"expires_at"`
 	IsRevoked  bool      `json:"is_revoked"`
-	LastUsedAt time.Time `json:"last_used_at"`
 	CreatedAt  time.Time `json:"created_at"`
 	UpdatedAt  time.Time `json:"updated_at"`
+	LastUsedAt time.Time `json:"last_used_at"`
+	RevokedAt  time.Time `json:"revoked_at"`
 }
 
 // VaultTokenCreate represents the data needed to create a new vault token

--- a/internal/types/vault_token.go
+++ b/internal/types/vault_token.go
@@ -14,6 +14,10 @@ type VaultToken struct {
 	RevokedAt  time.Time `json:"revoked_at"`
 }
 
+func (t *VaultToken) IsRevoked() bool {
+	return !t.RevokedAt.IsZero() && t.RevokedAt.Before(time.Now())
+}
+
 // VaultTokenCreate represents the data needed to create a new vault token
 type VaultTokenCreate struct {
 	PublicKey string    `json:"public_key"`

--- a/internal/types/vault_token.go
+++ b/internal/types/vault_token.go
@@ -8,7 +8,6 @@ type VaultToken struct {
 	TokenID    string    `json:"token_id"`
 	PublicKey  string    `json:"public_key"`
 	ExpiresAt  time.Time `json:"expires_at"`
-	IsRevoked  bool      `json:"is_revoked"`
 	CreatedAt  time.Time `json:"created_at"`
 	UpdatedAt  time.Time `json:"updated_at"`
 	LastUsedAt time.Time `json:"last_used_at"`

--- a/internal/types/vault_token.go
+++ b/internal/types/vault_token.go
@@ -4,18 +4,20 @@ import "time"
 
 // VaultToken represents a token stored in the database
 type VaultToken struct {
-	ID         string    `json:"id"`
-	TokenID    string    `json:"token_id"`
-	PublicKey  string    `json:"public_key"`
-	ExpiresAt  time.Time `json:"expires_at"`
-	CreatedAt  time.Time `json:"created_at"`
-	UpdatedAt  time.Time `json:"updated_at"`
-	LastUsedAt time.Time `json:"last_used_at"`
-	RevokedAt  time.Time `json:"revoked_at"`
+	ID         string     `json:"id"`
+	TokenID    string     `json:"token_id"`
+	PublicKey  string     `json:"public_key"`
+	ExpiresAt  time.Time  `json:"expires_at"`
+	CreatedAt  time.Time  `json:"created_at"`
+	UpdatedAt  time.Time  `json:"updated_at"`
+	LastUsedAt time.Time  `json:"last_used_at"`
+	RevokedAt  *time.Time `json:"revoked_at"`
 }
 
 func (t *VaultToken) IsRevoked() bool {
-	return !t.RevokedAt.IsZero() && t.RevokedAt.Before(time.Now())
+	return t.RevokedAt != nil &&
+		!t.RevokedAt.IsZero() &&
+		t.RevokedAt.Before(time.Now())
 }
 
 // VaultTokenCreate represents the data needed to create a new vault token

--- a/plugins-ui/src/modules/shared/wallet/Wallet.tsx
+++ b/plugins-ui/src/modules/shared/wallet/Wallet.tsx
@@ -39,7 +39,7 @@ const Wallet = () => {
       // add more switch cases as more chains are supported
       case "ethereum": {
         try {
- 
+
           const accounts = await VulticonnectWalletService.connectToVultiConnect();
 
           let is_authenticated = await signMessage();
@@ -52,7 +52,7 @@ const Wallet = () => {
             });
             return;
           }
- 
+
           if (accounts.length && accounts[0]) {
             setConnectedWallet(true);
             setWalletAddress(accounts[0]);
@@ -180,8 +180,8 @@ const Wallet = () => {
           >
             <span className="wallet-copy-tooltip">{copyTooltip}</span>
             <svg width="18" height="18" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <rect x="5" y="5" width="10" height="12" rx="3" fill="#64748b"/>
-              <rect x="8" y="2" width="9" height="12" rx="2" fill="#cbd5e1"/>
+              <rect x="5" y="5" width="10" height="12" rx="3" fill="#64748b" />
+              <rect x="8" y="2" width="9" height="12" rx="2" fill="#cbd5e1" />
             </svg>
           </button>
         </div>

--- a/plugins-ui/src/modules/shared/wallet/Wallet.tsx
+++ b/plugins-ui/src/modules/shared/wallet/Wallet.tsx
@@ -123,7 +123,7 @@ const Wallet = () => {
       // 7. Call auth endpoint
       const token = await MarketplaceService.getAuthToken(
         signingMessage,
-        signature.txHash,
+        signature,
         publicKey,
         chainCodeHex
       );


### PR DESCRIPTION
Closes #111

This PR addresses two issues:

1. On the typescript side, we started passing in `signature.txhash` - this attribute doesn't seem to exist, which results in the signature being omitted from the call to `/auth` (as of cc6e34bc0694449b4f2d5e9d35ae943bf01210fb on the extensions repo), which naturally fails the auth validation
2. Once [1] is addressed, JWT tokens aren't properly created due to drift between the updated schema and the go code. This PR refactors some of the vault tokens handling to be slightly cleaner, remove duplicate fields (issued_at is the same as created_at), and convert a revoked bool to a timestamp.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of wallet signature parsing to support signatures with a "0x" prefix.
  - Corrected argument passed to authentication token retrieval in wallet integration.

- **Database Migrations**
  - Removed unused `name` and `permissions` columns from vault tokens.
  - Added an `updated_at` timestamp column to vault tokens.

- **Improvements**
  - Switched token revocation tracking from a boolean flag to a timestamp, enhancing auditability and token management.
  - Updated token management to use revocation timestamps instead of boolean flags for more accurate status tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->