### PR TITLE
schema,registry: add fee plugin

### DIFF
--- a/common/migrations/system/20250530060312_add_fee_plugin_to_enum.sql
+++ b/common/migrations/system/20250530060312_add_fee_plugin_to_enum.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TYPE plugin_id ADD VALUE 'vultisig-fees-feee';
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ROLLBACK;
+-- +goose StatementEnd

--- a/types/registry.go
+++ b/types/registry.go
@@ -10,6 +10,7 @@ type PluginID string
 const (
 	PluginVultisigDCA_0000     PluginID = "vultisig-dca-0000"
 	PluginVultisigPayroll_0000 PluginID = "vultisig-payroll-0000"
+	PluginVultisigFees_feee    PluginID = "vultisig-fees-feee"
 )
 
 func (p PluginID) String() string {


### PR DESCRIPTION
Registers a plugin ID for the fee plugin

It's only fair that the random hex chars for this should be `feee`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the new "vultisig-fees-feee" plugin, enabling its selection and usage within the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->