### PR TITLE
feat: Add recipe specification endpoint with Redis caching

### DIFF
--- a/internal/api/plugin.go
+++ b/internal/api/plugin.go
@@ -330,3 +330,23 @@ func (s *Server) GetReviews(c echo.Context) error {
 
 	return c.JSON(http.StatusOK, reviews)
 }
+
+// GET /plugins/:pluginId/recipe-specification
+func (s *Server) GetPluginRecipeSpecification(c echo.Context) error {
+	pluginID := c.Param("pluginId")
+	if pluginID == "" {
+		return c.JSON(http.StatusBadRequest, NewErrorResponse("plugin id is required"))
+	}
+
+	fmt.Printf("[GetPluginRecipeSpecification] Getting recipe spec for pluginID=%s\n", pluginID)
+
+	recipeSpec, err := s.pluginService.GetPluginRecipeSpecification(c.Request().Context(), pluginID)
+	if err != nil {
+		s.logger.WithError(err).Error("Failed to get plugin recipe specification")
+		fmt.Printf("[GetPluginRecipeSpecification] Failed to get recipe spec: %v\n", err)
+		return c.JSON(http.StatusInternalServerError, NewErrorResponse("failed to get recipe specification"))
+	}
+
+	fmt.Printf("[GetPluginRecipeSpecification] Successfully got recipe spec for plugin %s\n", pluginID)
+	return c.JSON(http.StatusOK, recipeSpec)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -70,7 +70,7 @@ func NewServer(
 		logrus.Fatalf("Failed to initialize policy service: %v", err)
 	}
 
-	pluginService, err := service.NewPluginService(db, logger)
+	pluginService, err := service.NewPluginService(db, redis, logger)
 	if err != nil {
 		logrus.Fatalf("Failed to initialize plugin service: %v", err)
 	}
@@ -145,6 +145,7 @@ func (s *Server) StartServer() error {
 
 	pluginsGroup.GET("/:pluginId/reviews", s.GetReviews)
 	pluginsGroup.POST("/:pluginId/reviews", s.CreateReview, s.AuthMiddleware)
+	pluginsGroup.GET("/:pluginId/recipe-specification", s.GetPluginRecipeSpecification)
 
 	categoriesGroup := e.Group("/categories")
 	categoriesGroup.GET("", s.GetCategories)

--- a/internal/service/plugin.go
+++ b/internal/service/plugin.go
@@ -2,10 +2,15 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/sirupsen/logrus"
+	"github.com/vultisig/verifier/internal/storage"
 	"github.com/vultisig/verifier/internal/types"
 	ptypes "github.com/vultisig/verifier/types"
 )
@@ -13,6 +18,7 @@ import (
 type Plugin interface {
 	GetPluginWithRating(ctx context.Context, pluginId string) (*types.Plugin, error)
 	CreatePluginReviewWithRating(ctx context.Context, reviewDto types.ReviewCreateDto, pluginId string) (*types.ReviewDto, error)
+	GetPluginRecipeSpecification(ctx context.Context, pluginID string) (interface{}, error)
 }
 
 type PluginServiceStorage interface {
@@ -31,15 +37,17 @@ type PluginServiceStorage interface {
 
 type PluginService struct {
 	db     PluginServiceStorage
+	redis  *storage.RedisStorage
 	logger *logrus.Logger
 }
 
-func NewPluginService(db PluginServiceStorage, logger *logrus.Logger) (*PluginService, error) {
+func NewPluginService(db PluginServiceStorage, redis *storage.RedisStorage, logger *logrus.Logger) (*PluginService, error) {
 	if db == nil {
 		return nil, fmt.Errorf("database storage cannot be nil")
 	}
 	return &PluginService{
 		db:     db,
+		redis:  redis,
 		logger: logger,
 	}, nil
 }
@@ -107,4 +115,72 @@ func (s *PluginService) CreatePluginReviewWithRating(ctx context.Context, review
 		return nil, err
 	}
 	return review, nil
+}
+
+// GetPluginRecipeSpecification fetches recipe specification from plugin server with caching
+func (s *PluginService) GetPluginRecipeSpecification(ctx context.Context, pluginID string) (interface{}, error) {
+	// Check cache first
+	cacheKey := fmt.Sprintf("recipe_spec:%s", pluginID)
+
+	if s.redis != nil {
+		cached, err := s.redis.Get(ctx, cacheKey)
+		if err == nil && cached != "" {
+			var cachedSpec interface{}
+			if err := json.Unmarshal([]byte(cached), &cachedSpec); err == nil {
+				fmt.Printf("[GetPluginRecipeSpecification] Cache hit for plugin %s\n", pluginID)
+				return cachedSpec, nil
+			}
+		}
+	}
+
+	// Get plugin from database to get server endpoint
+	plugin, err := s.db.FindPluginById(ctx, nil, ptypes.PluginID(pluginID))
+	if err != nil {
+		return nil, fmt.Errorf("failed to find plugin: %w", err)
+	}
+
+	// Call plugin server endpoint
+	recipeSpec, err := s.fetchRecipeSpecificationFromPlugin(ctx, plugin.ServerEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch recipe specification from plugin: %w", err)
+	}
+
+	// Cache the result for 2 hours
+	if s.redis != nil {
+		specBytes, _ := json.Marshal(recipeSpec)
+		_ = s.redis.Set(ctx, cacheKey, string(specBytes), 2*time.Hour)
+		fmt.Printf("[GetPluginRecipeSpecification] Cached recipe spec for plugin %s\n", pluginID)
+	}
+
+	return recipeSpec, nil
+}
+
+// Helper method to call plugin server
+func (s *PluginService) fetchRecipeSpecificationFromPlugin(ctx context.Context, serverEndpoint string) (interface{}, error) {
+	url := fmt.Sprintf("%s/recipe-specification", strings.TrimSuffix(serverEndpoint, "/"))
+
+	fmt.Printf("[fetchRecipeSpecificationFromPlugin] Calling plugin endpoint: %s\n", url)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call plugin endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("plugin endpoint returned status %d", resp.StatusCode)
+	}
+
+	var recipeSpec interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&recipeSpec); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return recipeSpec, nil
 }


### PR DESCRIPTION
### Summary
Adds a new API endpoint to fetch plugin recipe specifications from plugin servers with Redis caching support.

### Changes
- **API Endpoint**: Added `GET /plugins/:pluginId/recipe-specification` 
- **Service Layer**: Implemented `GetPluginRecipeSpecification` method in PluginService
- **Caching**: Added 2-hour Redis cache to minimize plugin server requests
- **HTTP Client**: Added helper method to call plugin server `/recipe-specification` endpoints

### Technical Details
- Plugin specifications are cached in Redis with key `recipe_spec:{pluginId}` for 2 hours
- HTTP client uses 30-second timeout for plugin server calls
- Falls back to plugin server if cache miss occurs
- Server endpoint retrieved from plugin database record

### API Usage
```http
GET /plugins/{pluginId}/recipe-specification
```

### Flow
1. UI calls verifier API endpoint
2. Verifier checks Redis cache for existing specification
3. On cache miss, verifier calls plugin server's `/recipe-specification` endpoint
4. Response cached and returned to UI

### Dependencies
- Updated PluginService constructor to accept Redis storage
- Modified server initialization to pass Redis to PluginService

This enables the UI to dynamically generate policy creation forms based on plugin-specific recipe specifications.