### PR TITLE
api/plugin/sign: use recipe engine for policy and transaction validations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/vultisig/commondata v0.0.0-20250430024109-a2492623ef05
 	github.com/vultisig/go-wrappers v0.0.0-20250403041248-86911e8aa33f
 	github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74
-	github.com/vultisig/recipes v0.0.0-20250531074825-c4872dec4ab9
+	github.com/vultisig/recipes v0.0.0-20250604200546-de46ca82ef0d
 	github.com/vultisig/vultiserver v0.0.0-20250515110921-82d56d3d9cc9
 	golang.org/x/crypto v0.36.0
 	golang.org/x/sync v0.12.0

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/vultisig/commondata v0.0.0-20250430024109-a2492623ef05
 	github.com/vultisig/go-wrappers v0.0.0-20250403041248-86911e8aa33f
 	github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74
-	github.com/vultisig/recipes v0.0.0-20250604200546-de46ca82ef0d
+	github.com/vultisig/recipes v0.0.0-20250604212709-58772375f814
 	github.com/vultisig/vultiserver v0.0.0-20250515110921-82d56d3d9cc9
 	golang.org/x/crypto v0.36.0
 	golang.org/x/sync v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -726,10 +726,8 @@ github.com/vultisig/go-wrappers v0.0.0-20250403041248-86911e8aa33f h1:124Xlloih1
 github.com/vultisig/go-wrappers v0.0.0-20250403041248-86911e8aa33f/go.mod h1:UfGCxUQW08kiwxyNBiHwXe+ePPuBmHVVS+BS51aU/Jg=
 github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74 h1:goqwk4nQ/NEVIb3OPP9SUx7/u9ZfsUIcd5fIN/e4DVU=
 github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74/go.mod h1:nOykk4nOy1L3yXtLSlYvVsgizBnCQ3tR2N5uwGPdvaM=
-github.com/vultisig/recipes v0.0.0-20250531074825-c4872dec4ab9 h1:SSGqON8i7paf3/F7Vmc3RvsmrEETkb93k8+oH9VCLfM=
-github.com/vultisig/recipes v0.0.0-20250531074825-c4872dec4ab9/go.mod h1:tGlNiMDC33gPdX3C1DSESfQeCsaiOx+SNzInnF/Oi68=
-github.com/vultisig/recipes v0.0.0-20250604200546-de46ca82ef0d h1:8YpOKFAIAZIwGp55IMZELfLvOot5W+UgvXkxE60g9jw=
-github.com/vultisig/recipes v0.0.0-20250604200546-de46ca82ef0d/go.mod h1:BXXJ25U75xaexJLoiiaLEZ6TQrcy8+8UGJGd4c+hNSE=
+github.com/vultisig/recipes v0.0.0-20250604212709-58772375f814 h1:uY4x91tXkpDwuUOLBxUrG0ASvJzlvNKnbGqOMrBs0U8=
+github.com/vultisig/recipes v0.0.0-20250604212709-58772375f814/go.mod h1:BXXJ25U75xaexJLoiiaLEZ6TQrcy8+8UGJGd4c+hNSE=
 github.com/vultisig/vultiserver v0.0.0-20250515110921-82d56d3d9cc9 h1:pZhGN8q8+gPB1JJjVDC1hDg8qn6Tbj0XBJymgTQ8qQg=
 github.com/vultisig/vultiserver v0.0.0-20250515110921-82d56d3d9cc9/go.mod h1:HwP2IgW6Mcu/gX8paFuKvfibrGE9UmPgkOFTub6dskM=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/go.sum
+++ b/go.sum
@@ -728,6 +728,8 @@ github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74 h1:goqwk4n
 github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74/go.mod h1:nOykk4nOy1L3yXtLSlYvVsgizBnCQ3tR2N5uwGPdvaM=
 github.com/vultisig/recipes v0.0.0-20250531074825-c4872dec4ab9 h1:SSGqON8i7paf3/F7Vmc3RvsmrEETkb93k8+oH9VCLfM=
 github.com/vultisig/recipes v0.0.0-20250531074825-c4872dec4ab9/go.mod h1:tGlNiMDC33gPdX3C1DSESfQeCsaiOx+SNzInnF/Oi68=
+github.com/vultisig/recipes v0.0.0-20250604200546-de46ca82ef0d h1:8YpOKFAIAZIwGp55IMZELfLvOot5W+UgvXkxE60g9jw=
+github.com/vultisig/recipes v0.0.0-20250604200546-de46ca82ef0d/go.mod h1:BXXJ25U75xaexJLoiiaLEZ6TQrcy8+8UGJGd4c+hNSE=
 github.com/vultisig/vultiserver v0.0.0-20250515110921-82d56d3d9cc9 h1:pZhGN8q8+gPB1JJjVDC1hDg8qn6Tbj0XBJymgTQ8qQg=
 github.com/vultisig/vultiserver v0.0.0-20250515110921-82d56d3d9cc9/go.mod h1:HwP2IgW6Mcu/gX8paFuKvfibrGE9UmPgkOFTub6dskM=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/internal/api/plugin.go
+++ b/internal/api/plugin.go
@@ -15,9 +15,9 @@ import (
 	"github.com/vultisig/verifier/common"
 	"google.golang.org/protobuf/encoding/protojson"
 
-	"github.com/vultisig/recipes/ethereum"
+	"github.com/vultisig/recipes/chain"
+	"github.com/vultisig/recipes/engine"
 	rtypes "github.com/vultisig/recipes/types"
-	"github.com/vultisig/recipes/util"
 	"github.com/vultisig/verifier/internal/tasks"
 	"github.com/vultisig/verifier/internal/types"
 	ptypes "github.com/vultisig/verifier/types"
@@ -29,11 +29,6 @@ func (s *Server) SignPluginMessages(c echo.Context) error {
 	var req ptypes.PluginKeysignRequest
 	if err := c.Bind(&req); err != nil {
 		return fmt.Errorf("fail to parse request, err: %w", err)
-	}
-
-	// Plugin-specific validations
-	if len(req.Messages) != 1 {
-		return fmt.Errorf("plugin signing requires exactly one message hash, current: %d", len(req.Messages))
 	}
 
 	policyUUID, err := uuid.Parse(req.PolicyID)
@@ -62,61 +57,27 @@ func (s *Server) SignPluginMessages(c echo.Context) error {
 		return fmt.Errorf("failed to unmarshal recipe: %w", err)
 	}
 
-	// Presently we can only verify for payroll
-	if policy.PluginID != ptypes.PluginVultisigPayroll_0000 {
-		return fmt.Errorf("unsupported plugin ID: %s", policy.PluginID)
-	}
+	engine := engine.NewEngine()
 
-	transactionAllowedByPolicy := false
-
-	// Payroll only builds ethereum txs right now
-	ethChain := ethereum.NewEthereum()
-	decodedTx, err := ethChain.ParseTransaction(req.Transaction)
-	if err != nil {
-		return fmt.Errorf("failed to parse transaction: %w", err)
-	}
-
-	for _, rule := range recipe.GetRules() { // Use generated GetRules() getter
-		if rule == nil { // Defensive check
-			continue
-		}
-		resourcePathString := rule.GetResource() // Use generated getter
-		resourcePath, err := util.ParseResource(resourcePathString)
+	for _, keysignMessage := range req.Messages {
+		messageChain, err := chain.GetChain(string(keysignMessage.Chain))
 		if err != nil {
-			s.logger.WithError(err).Errorf("skipping rule %s: invalid resource path %s", rule.GetId(), resourcePathString)
-			continue
+			return fmt.Errorf("failed to get chain: %w", err)
 		}
 
-		if resourcePath.ChainId != "ethereum" {
-			s.logger.Errorf("skipping rule %s: target chain %s is not 'ethereum'", rule.GetId(), resourcePath.ChainId)
-			continue
-		}
-
-		protocol, err := ethChain.GetProtocol(resourcePath.ProtocolId)
+		decodedTx, err := messageChain.ParseTransaction(keysignMessage.Message)
 		if err != nil {
-			s.logger.WithError(err).Errorf("skipping rule %s: could not get protocol for asset '%s'", rule.GetId(), resourcePath.ProtocolId)
-			continue
+			return fmt.Errorf("failed to parse transaction: %w", err)
 		}
 
-		policyMatcher := &rtypes.PolicyFunctionMatcher{
-			FunctionID:  resourcePath.FunctionId,
-			Constraints: rule.GetParameterConstraints(), // Use generated getter
-		}
-
-		matches, _, err := protocol.MatchFunctionCall(decodedTx, policyMatcher)
+		transactionAllowed, _, err := engine.Evaluate(recipe, messageChain, decodedTx)
 		if err != nil {
-			s.logger.WithError(err).Errorf("error during transaction matching for rule %s, function %s", rule.GetId(), resourcePath.FunctionId)
-			continue
+			return fmt.Errorf("failed to evaluate policy: %w", err)
 		}
 
-		if matches {
-			transactionAllowedByPolicy = true
-			break
+		if !transactionAllowed {
+			return fmt.Errorf("transaction %s on %s not allowed by policy", keysignMessage.Hash, keysignMessage.Chain)
 		}
-	}
-
-	if !transactionAllowedByPolicy {
-		return fmt.Errorf("transaction does not match any rule in the policy")
 	}
 
 	// Reuse existing signing logic

--- a/internal/api/plugin.go
+++ b/internal/api/plugin.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -60,7 +61,7 @@ func (s *Server) SignPluginMessages(c echo.Context) error {
 	engine := engine.NewEngine()
 
 	for _, keysignMessage := range req.Messages {
-		messageChain, err := chain.GetChain(string(keysignMessage.Chain))
+		messageChain, err := chain.GetChain(strings.ToLower(keysignMessage.Chain.String()))
 		if err != nil {
 			return fmt.Errorf("failed to get chain: %w", err)
 		}


### PR DESCRIPTION
Closes #135

This PR enables:

1. Verification of multiple transactions in a single keysign request - This has some gaps in it right now (such as multiple identical txs passing validation) that will be addresses in a subsequent PR that adds some more bundle state management
2. ALL messages in a keysign request must pass, otherwise the API call fails
3. Supports validation of both bitcoin and ethereum txs vs. just ethereum previously
4. Removes guard clauses limiting the API to payroll plugin calls

Requires a go.mod update after https://github.com/vultisig/recipes/pull/18 is merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced transaction signing to support multiple blockchains with improved policy evaluation and immediate error feedback for disallowed transactions.

- **Chores**
	- Updated a dependency to the latest version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->