### PR TITLE
fix: Add readable frequency labels for scheduling options in recipe schema

### DIFF
--- a/plugins-ui/src/modules/plugin/components/recipe_schema/recipe_Schema.tsx
+++ b/plugins-ui/src/modules/plugin/components/recipe_schema/recipe_Schema.tsx
@@ -131,6 +131,18 @@ const RecipeSchema: React.FC<RecipeSchemaProps> = ({ pluginId, onClose }) => {
     return types.map(t => typeMap[t] || `Type ${t}`).join(', ');
   };
 
+  const getFrequencyLabel = (frequency: number) => {
+    const frequencyMap: Record<number, string> = {
+      0: "Unspecified",
+      1: "Hourly",
+      2: "Daily",
+      3: "Weekly",
+      4: "Biweekly",
+      5: "Monthly"
+    };
+    return frequencyMap[frequency] || `Frequency ${frequency}`;
+  };
+
   useEffect(() => {
     fetchSchema();
   }, [pluginId]);
@@ -264,7 +276,7 @@ const RecipeSchema: React.FC<RecipeSchemaProps> = ({ pluginId, onClose }) => {
                     <option value="">Select frequency...</option>
                     {schema.scheduling.supported_frequencies.map(freq => (
                       <option key={freq} value={freq}>
-                        {freq === 3 ? 'Daily' : freq === 4 ? 'Weekly' : freq === 5 ? 'Monthly' : `Frequency ${freq}`}
+                        {getFrequencyLabel(freq)}
                       </option>
                     ))}
                   </select>


### PR DESCRIPTION
Fixes scheduling section in plugin-ui by adding human-readable labels for frequency options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized the display of scheduling frequency labels in dropdown menus for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->