### PR TITLE
ui: fix auth

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,17 @@
                     enable = true;
                   };
 
+                  languages.typescript = {
+                    enable = true;
+                  };
+
+                  languages.javascript = {
+                    enable = true;
+                    package = pkgs.nodejs_22;
+                    npm.enable = true;
+                  };
+
+
                   packages = with pkgs; [ 
                     redis
                     goose

--- a/internal/sigutil/signing.go
+++ b/internal/sigutil/signing.go
@@ -76,8 +76,11 @@ func VerifyEthAddressSignature(address common.Address, messageBytes []byte, sign
 		return false, fmt.Errorf("invalid signature length: expected 65 bytes, got %d", len(signatureBytes))
 	}
 
-	if signatureBytes[64] >= 27 {
-		signatureBytes[64] -= 27
+	sigCopy := make([]byte, 65)
+	copy(sigCopy, signatureBytes)
+
+	if sigCopy[64] >= 27 {
+		sigCopy[64] -= 27
 	}
 
 	// Create the Ethereum prefixed message hash
@@ -85,7 +88,7 @@ func VerifyEthAddressSignature(address common.Address, messageBytes []byte, sign
 	prefixedHash := crypto.Keccak256Hash([]byte(prefixedMessage))
 
 	// Recover public key from signature
-	pubkeyBytes, err := crypto.Ecrecover(prefixedHash.Bytes(), signatureBytes)
+	pubkeyBytes, err := crypto.Ecrecover(prefixedHash.Bytes(), sigCopy)
 	if err != nil {
 		return false, fmt.Errorf("failed to recover public key: %w", err)
 	}

--- a/internal/sigutil/signing.go
+++ b/internal/sigutil/signing.go
@@ -76,6 +76,10 @@ func VerifyEthAddressSignature(address common.Address, messageBytes []byte, sign
 		return false, fmt.Errorf("invalid signature length: expected 65 bytes, got %d", len(signatureBytes))
 	}
 
+	if signatureBytes[64] == 27 || signatureBytes[64] == 28 {
+		signatureBytes[64] -= 27
+	}
+
 	// Create the Ethereum prefixed message hash
 	prefixedMessage := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", len(messageBytes), messageBytes)
 	prefixedHash := crypto.Keccak256Hash([]byte(prefixedMessage))

--- a/internal/sigutil/signing.go
+++ b/internal/sigutil/signing.go
@@ -76,7 +76,7 @@ func VerifyEthAddressSignature(address common.Address, messageBytes []byte, sign
 		return false, fmt.Errorf("invalid signature length: expected 65 bytes, got %d", len(signatureBytes))
 	}
 
-	if signatureBytes[64] == 27 || signatureBytes[64] == 28 {
+	if signatureBytes[64] >= 27 {
 		signatureBytes[64] -= 27
 	}
 

--- a/plugins-ui/src/modules/shared/wallet/Wallet.tsx
+++ b/plugins-ui/src/modules/shared/wallet/Wallet.tsx
@@ -41,8 +41,6 @@ const Wallet = () => {
 
           const accounts = await VulticonnectWalletService.connectToVultiConnect();
 
-          console.log("accounts", accounts);
-
           let is_authenticated = await signMessage(accounts[0]);
           console.log("is_authenticated", is_authenticated);
 
@@ -105,8 +103,6 @@ const Wallet = () => {
       // 4. Generate nonce and expiry timestamp
       const nonce = ethers.hexlify(ethers.randomBytes(16));
       const expiryTime = new Date(Date.now() + 15 * 60 * 1000).toISOString(); // 15 minutes from now
-
-      console.log("walletAddress", walletAddress);
 
       // 5. Generate hex message for signing
       const signingMessage = JSON.stringify({

--- a/plugins-ui/src/modules/shared/wallet/Wallet.tsx
+++ b/plugins-ui/src/modules/shared/wallet/Wallet.tsx
@@ -41,7 +41,9 @@ const Wallet = () => {
 
           const accounts = await VulticonnectWalletService.connectToVultiConnect();
 
-          let is_authenticated = await signMessage();
+          console.log("accounts", accounts);
+
+          let is_authenticated = await signMessage(accounts[0]);
           console.log("is_authenticated", is_authenticated);
 
           if (!is_authenticated) {
@@ -80,7 +82,7 @@ const Wallet = () => {
   };
 
   // sign message
-  const signMessage = async () => {
+  const signMessage = async (walletAddress: string) => {
     try {
       // 1. Get vaults from VultiConnect
       const vaults = await VulticonnectWalletService.getVaults();
@@ -89,6 +91,7 @@ const Wallet = () => {
       }
 
       // 2. Get required data from first vault
+      // TODO: Get vault details and address from selected vault, don't default to first
       const publicKey = vaults[0].publicKeyEcdsa;
       const chainCodeHex = vaults[0].hexChainCode;
 
@@ -102,6 +105,8 @@ const Wallet = () => {
       // 4. Generate nonce and expiry timestamp
       const nonce = ethers.hexlify(ethers.randomBytes(16));
       const expiryTime = new Date(Date.now() + 15 * 60 * 1000).toISOString(); // 15 minutes from now
+
+      console.log("walletAddress", walletAddress);
 
       // 5. Generate hex message for signing
       const signingMessage = JSON.stringify({


### PR DESCRIPTION
Fixes auth to work with the updated extension

1. Passes in the wallet address before sign in is complete - previously, before we had sign in working, we set the connected wallet data into the store immediately - now, it happens after auth, but the sign in message tries to reference the store, which results in an empty address - this should be fixed more properly to use the selected vault, not just default to the first one though
2. Adjusts the recovery ID to match go-ethereum's `crypto.Ecrecover` expectations - it requires the recovery ID to be 0-4, while extensions (not just vultisig) typically produce 27-31.

https://github.com/ethereum/go-ethereum/blob/3cc0e7a31ab8d070dbacf77412f935b6bb789054/crypto/secp256k1/secp256.go#L167-L169 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced development environment with TypeScript and JavaScript support, including Node.js 22 and npm integration.

- **Refactor**
  - Updated wallet authentication flow to explicitly use the wallet address during message signing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->