### PR TITLE
fix: extend timeout duration for key generation process in reshare.go

### DIFF
--- a/vault/reshare.go
+++ b/vault/reshare.go
@@ -279,7 +279,7 @@ func (t *DKLSTssService) processQcInbound(handle Handle,
 	for {
 		select {
 		case <-time.After(time.Millisecond * 100):
-			if time.Since(start) > time.Minute {
+			if time.Since(start) > time.Minute*2 {
 				// set isKeygenFinished to true , so the other go routine can be stopped
 				t.isKeygenFinished.Store(true)
 				return "", "", TssKeyGenTimeout


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased the timeout duration for certain processing tasks, allowing more time before a timeout occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->