### PR TITLE
api/recipe-specification: fix upstream plugin path

### DIFF
--- a/internal/service/plugin.go
+++ b/internal/service/plugin.go
@@ -206,7 +206,7 @@ func (s *PluginService) GetPluginRecipeSpecification(ctx context.Context, plugin
 
 // Helper method to call plugin server
 func (s *PluginService) fetchRecipeSpecificationFromPlugin(ctx context.Context, serverEndpoint string) (interface{}, error) {
-	url := fmt.Sprintf("%s/recipe-specification", strings.TrimSuffix(serverEndpoint, "/"))
+	url := fmt.Sprintf("%s/plugin/recipe-specification", strings.TrimSuffix(serverEndpoint, "/"))
 
 	s.logger.Debugf("[fetchRecipeSpecificationFromPlugin] Calling plugin endpoint: %s\n", url)
 


### PR DESCRIPTION
Fixed #165

On the plugin server, the recipe-specification endpoint is under the `/plugin` group.

This lets the schema load properly and render the form

<img width="1707" alt="Screenshot 2025-06-16 at 7 31 32 AM" src="https://github.com/user-attachments/assets/4861462b-700a-4622-95c7-f8a64e47d548" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the endpoint used to fetch recipe specifications from the plugin server, ensuring the correct path is accessed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->