### PR TITLE
Add plugin id to reshare request

### DIFF
--- a/plugins-ui/src/modules/shared/wallet/vulticonnectWalletService.ts
+++ b/plugins-ui/src/modules/shared/wallet/vulticonnectWalletService.ts
@@ -130,6 +130,7 @@ const VulticonnectWalletService = {
     try {
       const response = await window.vultisig.plugin.request({
         method: "plugin_request_reshare",
+        params: [{ id: pluginId }],
       });
       console.log("response", response);
       // Example response: vultisig://vultisig.com?type=NewVault&tssType=Reshare&jsonData=...


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved plugin request handling by explicitly passing the plugin ID as a parameter during wallet reshare sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->