### PR TITLE
common: handle unencrypted vaults during parsing

### DIFF
--- a/common/utils.go
+++ b/common/utils.go
@@ -151,6 +151,11 @@ func DecryptVaultFromBackup(password string, vaultBackupRaw []byte) (*vaultType.
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		vaultRaw, err = base64.StdEncoding.DecodeString(vaultBackup.Vault)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var vault vaultType.Vault

--- a/common/utils.go
+++ b/common/utils.go
@@ -140,7 +140,7 @@ func DecryptVaultFromBackup(password string, vaultBackupRaw []byte) (*vaultType.
 		return nil, err
 	}
 
-	vaultRaw := []byte(vaultBackup.Vault)
+	var vaultRaw []byte
 	if vaultBackup.IsEncrypted {
 		// decrypt the vault
 		vaultBytes, err := base64.StdEncoding.DecodeString(vaultBackup.Vault)


### PR DESCRIPTION
Fixes #211

We b64 encode vault data before storing it in the container. However, the current decryption flow in utils only decodes it during the decription process - if a vault is not encrypted, the b64 decoding is skipped, and we attempt to parse a b64 string directly as a protobuf message.

This aligns the decoding with other apps so that we can handle both cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of vault backups that are not encrypted, ensuring proper loading and decoding in both encrypted and unencrypted scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->