### PR TITLE
Fix GetAllPluginPolicies

### DIFF
--- a/internal/api/policy.go
+++ b/internal/api/policy.go
@@ -230,14 +230,13 @@ func (s *Server) GetPluginPolicyById(c echo.Context) error {
 }
 
 func (s *Server) GetAllPluginPolicies(c echo.Context) error {
-	publicKey := c.Request().Header.Get("public_key")
-	if publicKey == "" {
-		return c.JSON(http.StatusBadRequest, NewErrorResponse(http.StatusBadRequest, "failed to get policies", ""))
-	}
-
-	pluginID := c.Request().Header.Get("plugin_id")
+	pluginID := c.Param("pluginId")
 	if pluginID == "" {
-		return c.JSON(http.StatusBadRequest, NewErrorResponse(http.StatusBadRequest, "failed to get policies", ""))
+		return c.JSON(http.StatusBadRequest, NewErrorResponse(http.StatusBadRequest, "Plugin ID is required", ""))
+	}
+	publicKey, ok := c.Get("vault_public_key").(string)
+	if !ok {
+		return c.JSON(http.StatusInternalServerError, NewErrorResponse(http.StatusInternalServerError, "Failed to get vault public key", ""))
 	}
 
 	skip, err := strconv.Atoi(c.QueryParam("skip"))

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -147,7 +147,7 @@ func (s *Server) StartServer() error {
 	pluginGroup.DELETE("/:pluginId", s.DeletePlugin) // Delete plugin
 	pluginGroup.POST("/policy", s.CreatePluginPolicy)
 	pluginGroup.PUT("/policy", s.UpdatePluginPolicyById)
-	pluginGroup.GET("/policies", s.GetAllPluginPolicies)
+	pluginGroup.GET("/policies/:pluginId", s.GetAllPluginPolicies)
 	pluginGroup.GET("/policy/:policyId", s.GetPluginPolicyById)
 	pluginGroup.DELETE("/policy/:policyId", s.DeletePluginPolicyById)
 	pluginGroup.GET("/policies/:policyId/history", s.GetPluginPolicyTransactionHistory)

--- a/plugins-ui/src/modules/marketplace/services/marketplaceService.ts
+++ b/plugins-ui/src/modules/marketplace/services/marketplaceService.ts
@@ -92,10 +92,7 @@ const MarketplaceService = {
     take: number
   ): Promise<{ policies: PluginPolicy[]; total_count: number }> => {
     return get(
-      `${getMarketplaceUrl()}/plugin/policies?skip=${skip}&take=${take}`,
-      {
-        headers: { plugin_id: pluginId, public_key: getCurrentVaultId() },
-      }
+      `${getMarketplaceUrl()}/plugin/policies/${pluginId}?skip=${skip}&take=${take}`
     );
   },
 


### PR DESCRIPTION
- `pluginId` should be passed as a URL parameter to stay consistent with the pattern used in other endpoints.
- There's no need to fetch `public_key` from the request headers, as it's already available in the JWT token.
- This new approach ensures that each user can only fetch their own policies. With the previous implementation, a user (e.g., User A) could pass the public key of another user (e.g., User B) and access their policies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the API endpoint for retrieving plugin policies to require a plugin ID in the URL path.
* **Bug Fixes**
  * Improved error messages for missing plugin ID during policy retrieval.
* **Chores**
  * Adjusted the UI service to match the new API endpoint and removed the need for custom headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->