### PR TITLE
prefix

### DIFF
--- a/worker.example.json
+++ b/worker.example.json
@@ -3,7 +3,7 @@
     "relay": {
       "server": "https://api.vultisig.com/router"
     },
-    "local_party_prefix": "verifier-",
+    "local_party_prefix": "verifier",
     "encryption_secret": "test123"
   },
   "redis": {


### PR DESCRIPTION
Current one makes local party as `verifier--xxx` with double hyphen and discovery doesn't work