### PR TITLE
✨ Add endpoint and functionality to mark verifier fees as collected

### DIFF
--- a/internal/service/auth_test.go
+++ b/internal/service/auth_test.go
@@ -167,6 +167,14 @@ func (m *MockDatabaseStorage) GetAllFeesByPolicyId(ctx context.Context, policyId
 	return args.Get(0).([]types.Fee), args.Error(1)
 }
 
+func (m *MockDatabaseStorage) MarkFeesCollected(ctx context.Context, collectedAt time.Time, ids []uuid.UUID, txHash string) ([]types.Fee, error) {
+	args := m.Called(ctx, collectedAt, ids, txHash)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]types.Fee), args.Error(1)
+}
+
 func (m *MockDatabaseStorage) GetFeesByPublicKey(ctx context.Context, publicKey string, includeCollected bool) ([]types.Fee, error) {
 	args := m.Called(ctx, publicKey, includeCollected)
 	if args.Get(0) == nil {

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -49,6 +50,7 @@ type FeeRepository interface {
 	GetFeesByPublicKey(ctx context.Context, publicKey string, includeCollected bool) ([]types.Fee, error)
 	GetAllFeesByPublicKey(ctx context.Context, includeCollected bool) ([]types.Fee, error)
 	InsertFee(ctx context.Context, dbTx pgx.Tx, fee types.Fee) (*types.Fee, error)
+	MarkFeesCollected(ctx context.Context, collectedAt time.Time, ids []uuid.UUID, txid string) ([]types.Fee, error)
 }
 
 type PluginPolicySyncRepository interface {

--- a/internal/storage/postgres/migrations/verifier/20250529070558_add_fees.sql
+++ b/internal/storage/postgres/migrations/verifier/20250529070558_add_fees.sql
@@ -23,10 +23,11 @@ CREATE TABLE IF NOT EXISTS fees(
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     plugin_policy_billing_id uuid NOT NULL, -- used for recurring fees
     transaction_id uuid, -- used for tx based fees only
+    transaction_hash VARCHAR(66), -- The hash of the transaction that collected the fee
     amount BIGINT NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT now(),
     charged_at DATE NOT NULL DEFAULT now(),
-    collected_at TIME,
+    collected_at TIMESTAMP,
     CONSTRAINT fk_billing FOREIGN KEY (plugin_policy_billing_id) REFERENCES plugin_policy_billing(id) ON DELETE CASCADE
 );
 

--- a/internal/storage/postgres/schema/schema.sql
+++ b/internal/storage/postgres/schema/schema.sql
@@ -63,10 +63,11 @@ CREATE TABLE "fees" (
     "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
     "plugin_policy_billing_id" "uuid" NOT NULL,
     "transaction_id" "uuid",
+    "transaction_hash" character varying(66),
     "amount" bigint NOT NULL,
     "created_at" timestamp without time zone DEFAULT "now"() NOT NULL,
     "charged_at" "date" DEFAULT "now"() NOT NULL,
-    "collected_at" time without time zone
+    "collected_at" timestamp without time zone
 );
 
 CREATE TABLE "plugin_policies" (
@@ -102,6 +103,7 @@ CREATE VIEW "fees_view" AS
     "f"."id",
     "f"."plugin_policy_billing_id",
     "f"."transaction_id",
+    "f"."transaction_hash",
     "f"."amount",
     "f"."created_at",
     "f"."charged_at",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to mark multiple fees as collected, including specifying a transaction hash and collection timestamp.
  * Updated API to return the updated fee records after marking as collected.

* **Database Changes**
  * Added a new column to the fees table to store the transaction hash associated with fee collection.
  * Updated database views to include the new transaction hash column.
  * Changed the collected_at column type from time to timestamp for more precise tracking.

* **Bug Fixes**
  * Ensured accurate update and retrieval of fee records when marking as collected, with improved error handling and transaction management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->