### PR TITLE
storage: don't log DSN

### DIFF
--- a/internal/storage/postgres/db.go
+++ b/internal/storage/postgres/db.go
@@ -23,7 +23,6 @@ type MigrationOptions struct {
 }
 
 func NewPostgresBackend(dsn string, opts *MigrationOptions) (*PostgresBackend, error) {
-	logrus.Info("Connecting to database with DSN: ", dsn)
 	pool, err := pgxpool.New(context.Background(), dsn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)


### PR DESCRIPTION
Since we stream logs to graylog now, we shouldn't log the DSN including the password and host details

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed logging of database connection details during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->