### PR TITLE
🐛 Render empty config values in policy modal

### DIFF
--- a/plugins-ui/src/components/PluginPolicyModal.tsx
+++ b/plugins-ui/src/components/PluginPolicyModal.tsx
@@ -181,7 +181,7 @@ export const PluginPolicyModal: FC<PluginPolicyModalProps> = ({
       if (schema.configuration) {
         const configuration: Record<string, any> = {};
 
-        Object.entries(schema.configuration.properties).forEach(
+        Object.entries(schema?.configuration?.properties || {}).forEach(
           ([key, field]) => {
             if (values[key]) {
               switch (field.format) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin Policy modal no longer errors when a plugin lacks configuration or properties; it now safely renders with an empty configuration list.
  * Improved stability for plugins with incomplete schemas, preventing unexpected crashes while preserving existing behavior when configuration is present.
  * Users should experience smoother loading and fewer interruptions when opening the modal across a wider range of plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->