### PR TITLE
✨ Time based fee changes

### DIFF
--- a/internal/service/auth_test.go
+++ b/internal/service/auth_test.go
@@ -183,8 +183,8 @@ func (m *MockDatabaseStorage) MarkFeesCollected(ctx context.Context, collectedAt
 	return args.Get(0).([]types.Fee), args.Error(1)
 }
 
-func (m *MockDatabaseStorage) GetFeesByPublicKey(ctx context.Context, publicKey string, includeCollected bool) ([]types.Fee, error) {
-	args := m.Called(ctx, publicKey, includeCollected)
+func (m *MockDatabaseStorage) GetFeesByPublicKey(ctx context.Context, publicKey string, since *time.Time) ([]types.Fee, error) {
+	args := m.Called(ctx, publicKey, since)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}

--- a/internal/service/fees.go
+++ b/internal/service/fees.go
@@ -30,7 +30,7 @@ import (
 )
 
 type Fees interface {
-	PublicKeyGetFeeInfo(ctx context.Context, publicKey string) (*itypes.FeeHistoryDto, error)
+	PublicKeyGetFeeInfo(ctx context.Context, publicKey string, since *time.Time) (*itypes.FeeHistoryDto, error)
 	MarkFeesCollected(ctx context.Context, collectedAt time.Time, ids []uuid.UUID, txHash string) ([]itypes.FeeDto, error)
 }
 
@@ -56,9 +56,9 @@ func NewFeeService(db storage.DatabaseStorage,
 	}, nil
 }
 
-func (s *FeeService) PublicKeyGetFeeInfo(ctx context.Context, publicKey string) (*itypes.FeeHistoryDto, error) {
+func (s *FeeService) PublicKeyGetFeeInfo(ctx context.Context, publicKey string, since *time.Time) (*itypes.FeeHistoryDto, error) {
 
-	fees, err := s.db.GetFeesByPublicKey(ctx, publicKey, true)
+	fees, err := s.db.GetFeesByPublicKey(ctx, publicKey, since)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get fees: %w", err)
 	}
@@ -249,7 +249,7 @@ func (s *FeeService) ValidateFees(ctx context.Context, req *ptypes.PluginKeysign
 		return fmt.Errorf("transaction must be sent to the configured usdc contract address")
 	}
 
-	feeInfo, err := s.PublicKeyGetFeeInfo(ctx, req.PublicKey)
+	feeInfo, err := s.PublicKeyGetFeeInfo(ctx, req.PublicKey, nil)
 	if err != nil {
 		return fmt.Errorf("internal error")
 	}

--- a/internal/storage/db.go
+++ b/internal/storage/db.go
@@ -48,7 +48,7 @@ type PolicyRepository interface {
 
 type FeeRepository interface {
 	GetAllFeesByPolicyId(ctx context.Context, policyId uuid.UUID) ([]types.Fee, error)
-	GetFeesByPublicKey(ctx context.Context, publicKey string, includeCollected bool) ([]types.Fee, error)
+	GetFeesByPublicKey(ctx context.Context, publicKey string, since *time.Time) ([]types.Fee, error)
 	GetAllFeesByPublicKey(ctx context.Context, includeCollected bool) ([]types.Fee, error)
 	InsertFee(ctx context.Context, dbTx pgx.Tx, fee types.Fee) (*types.Fee, error)
 	MarkFeesCollected(ctx context.Context, collectedAt time.Time, ids []uuid.UUID, txid string) ([]types.Fee, error)


### PR DESCRIPTION
Update the verifier to enable time based fee querying

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional since query parameter to the fees-by-public-key API to return fees created on or after a given RFC3339 timestamp.
  * When since is omitted, behavior remains unchanged (no time filtering).
  * Invalid since values now return 400 Bad Request with a clear "invalid since time" error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->