### PR TITLE
ci: fix pg_dump v17 restriction

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -162,6 +162,8 @@ jobs:
             -e '/^--.*/d' \
             -e '/^SET /d' \
             -e '/^SELECT pg_catalog./d' \
+            -e '/^\\restrict /d' \
+            -e '/^\\unrestrict /d' \
             -e 's/"public"\.//' | awk '/./ { e=0 } /^$$/ { e += 1 } e <= 1' \
             > ./current_schema.sql
 


### PR DESCRIPTION
Postgres 17 introduced a fix for [CVE-2025-8714](https://www.postgresql.org/support/security/CVE-2025-8714/), which results in a change to the `pg_dump` output.

Since schema.sql is trusted and not used with `pg_restore`, and only used to sanity check our PRs, we can ignore this for the moment.
