### PR TITLE
Fix plugin policy suggest decode

### DIFF
--- a/internal/api/plugin.go
+++ b/internal/api/plugin.go
@@ -23,6 +23,7 @@ import (
 	"github.com/vultisig/verifier/tx_indexer/pkg/storage"
 	ptypes "github.com/vultisig/verifier/types"
 	"github.com/vultisig/vultisig-go/common"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 func (s *Server) SignPluginMessages(c echo.Context) error {
@@ -390,5 +391,18 @@ func (s *Server) GetPluginRecipeSpecificationSuggest(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, NewErrorResponseWithMessage("failed to get recipe suggest"))
 	}
 
-	return c.JSON(http.StatusOK, recipeSpec)
+	b, err := protojson.Marshal(recipeSpec)
+	if err != nil {
+		s.logger.WithError(err).Error("failed to proto marshal")
+		return c.JSON(http.StatusInternalServerError, NewErrorResponseWithMessage("failed to proto marshal"))
+	}
+
+	var res map[string]any
+	err = json.Unmarshal(b, &res)
+	if err != nil {
+		s.logger.WithError(err).Error("failed to json marshal")
+		return c.JSON(http.StatusInternalServerError, NewErrorResponseWithMessage("failed to json marshal"))
+	}
+
+	return c.JSON(http.StatusOK, res)
 }

--- a/internal/service/plugin.go
+++ b/internal/service/plugin.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 	rtypes "github.com/vultisig/recipes/types"
 	"github.com/vultisig/verifier/plugin/libhttp"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/vultisig/verifier/internal/storage"
 	"github.com/vultisig/verifier/internal/types"
@@ -227,8 +228,9 @@ func (s *PluginService) GetPluginRecipeSpecificationSuggest(
 	type req struct {
 		Configuration map[string]any `json:"configuration"`
 	}
+	plugin.ServerEndpoint = "https://dca.vultisigplugin.app"
 
-	recipeSpec, err := libhttp.Call[*rtypes.PolicySuggest](
+	policySuggestStr, err := libhttp.Call[string](
 		ctx,
 		http.MethodPost,
 		plugin.ServerEndpoint+"/plugin/recipe-specification/suggest",
@@ -243,8 +245,12 @@ func (s *PluginService) GetPluginRecipeSpecificationSuggest(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get recipe spec: %w", err)
 	}
-
-	return recipeSpec, nil
+	var policySuggest rtypes.PolicySuggest
+	err = protojson.Unmarshal([]byte(policySuggestStr), &policySuggest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal recipe spec: %w", err)
+	}
+	return &policySuggest, nil
 }
 
 // Helper method to call plugin server

--- a/internal/service/plugin.go
+++ b/internal/service/plugin.go
@@ -228,7 +228,6 @@ func (s *PluginService) GetPluginRecipeSpecificationSuggest(
 	type req struct {
 		Configuration map[string]any `json:"configuration"`
 	}
-	plugin.ServerEndpoint = "https://dca.vultisigplugin.app"
 
 	policySuggestStr, err := libhttp.Call[string](
 		ctx,

--- a/plugin/libhttp/libhttp.go
+++ b/plugin/libhttp/libhttp.go
@@ -60,10 +60,8 @@ func Call[T comparable](
 		return *new(T), fmt.Errorf("failed to get successful response: status_code: %d, res_body: %s", res.StatusCode, string(bodyBytes))
 	}
 
-	bodyStr, isString := any(new(T)).(string)
-	if isString {
-		// for string response type no need to unmarshal JSON
-		return any(bodyStr).(T), nil
+	if _, ok := any(*new(T)).(string); ok {
+		return any(string(bodyBytes)).(T), nil
 	}
 
 	var r T

--- a/plugin/libhttp/libhttp_test.go
+++ b/plugin/libhttp/libhttp_test.go
@@ -1,0 +1,52 @@
+package libhttp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+type respStruct struct {
+	Message string `json:"message"`
+	N       int    `json:"n"`
+}
+
+func TestCall_String(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("hello world"))
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	got, err := Call[string](ctx, http.MethodGet, srv.URL, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("Call[string] error: %v", err)
+	}
+	if got != "hello world" {
+		t.Fatalf("want %q, got %q", "hello world", got)
+	}
+}
+
+func TestCall_JSONStruct(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(respStruct{Message: "ok", N: 42})
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	got, err := Call[respStruct](ctx, http.MethodGet, srv.URL, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("Call[respStruct] error: %v", err)
+	}
+	if got.Message != "ok" || got.N != 42 {
+		t.Fatalf("unexpected: %#v", got)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Recipe suggestion responses are now decoded from protobuf JSON into structured suggestion objects with explicit error handling.
- Bug Fixes
  - Fewer failures when fetching and decoding recipe suggestion data from varied response formats.
- Refactor
  - HTTP response handling improved to reliably support both plain-text and JSON payloads.
- Tests
  - Added automated tests covering string and JSON HTTP responses to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->