### PR TITLE
🐛 Remove the \restrict tag from the pg_dump data

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -159,6 +159,8 @@ jobs:
             --quote-all-identifiers \
             -T public.goose_db_version \
             -T public.goose_db_version_id_seq | sed \
+            -e '/^\\restrict /d' \
+            -e '/^\\unrestrict /d' \
             -e '/^--.*/d' \
             -e '/^SET /d' \
             -e '/^SELECT pg_catalog./d' \

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,8 @@ dump-schema:
 		--quote-all-identifiers \
 		-T public.goose_db_version \
 		-T public.goose_db_version_id_seq | sed \
+		-e '/^\\restrict /d' \
+    	-e '/^\\unrestrict /d' \
 		-e '/^--.*/d' \
 		-e '/^SET /d' \
 		-e '/^SELECT pg_catalog./d' \


### PR DESCRIPTION
With postgres:16 `\restrict`tags are added to the db schema when performing a db_dump. This removes them from the output