### PR TITLE
Fix plugin uninstall

### DIFF
--- a/plugin/server/server.go
+++ b/plugin/server/server.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"math/big"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -239,6 +240,12 @@ func (s *Server) handleDeleteVault(c echo.Context) error {
 
 	fileName := vcommon.GetVaultBackupFilename(publicKeyECDSA, pluginId)
 	if err := s.vaultStorage.DeleteFile(fileName); err != nil {
+		// Check if it's a "file not found" error
+		if os.IsNotExist(err) {
+			// File doesn't exist - deletion "succeeded" (idempotent)
+			return c.NoContent(http.StatusOK)
+		}
+		// Real error (S3 failure, permissions, etc.)
 		return c.JSON(http.StatusInternalServerError, NewErrorResponse(err.Error()))
 	}
 	return c.NoContent(http.StatusOK)


### PR DESCRIPTION
In #418 , both policy deletion and plugin uninstallation has been modified to always delete policy and uninstall plugin regardless of what plugin server does, in order to give users the ability to stop policies even if plugin server is not available. This is fine for policy deletion, but for plugin uninstall we need to ensure that both plugin server and verifier are synced in terms of who holds a keyshare. This PR reverts the previous changes to plugin uninstall, and checks that plugin server doesnt return an error if the keyshare is not found. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced plugin deletion workflow with improved error handling, including specific service unavailability responses and explicit error handling for policy deletion operations.
  * Improved vault file deletion to gracefully handle file-not-found scenarios, treating them as idempotent successful operations rather than errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->