### PR TITLE
vm logger fix

### DIFF
--- a/plugin/server/middleware.go
+++ b/plugin/server/middleware.go
@@ -25,11 +25,13 @@ func DefaultMiddlewares() []echo.MiddlewareFunc {
 // VictoriaMetricsLogger creates a middleware that logs HTTP requests in Victoria Metrics compatible format
 func VictoriaMetricsLogger() echo.MiddlewareFunc {
 	return middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
-		LogURI:      true,
-		LogStatus:   true,
-		LogMethod:   true,
-		LogLatency:  true,
-		LogRemoteIP: true,
+		LogURI:           true,
+		LogStatus:        true,
+		LogMethod:        true,
+		LogLatency:       true,
+		LogRemoteIP:      true,
+		LogError:         true,
+		LogContentLength: true,
 		LogValuesFunc: func(c echo.Context, v middleware.RequestLoggerValues) error {
 			// Use fmt.Printf to output JSON in Victoria Metrics compatible format
 			logEntry := map[string]interface{}{

--- a/plugin/server/server.go
+++ b/plugin/server/server.go
@@ -63,6 +63,11 @@ func NewServer(
 	metrics metrics.PluginServerMetrics, // Optional: pass nil to disable metrics
 	logger *logrus.Logger, // Pass your configured logger for consistent formatting
 ) *Server {
+	// Guard against nil logger to avoid startup panics
+	if logger == nil {
+		logger = logrus.New()
+	}
+
 	return &Server{
 		cfg:          cfg,
 		redis:        redis,


### PR DESCRIPTION
Replaces plugin server logger in middleware with victoria metrics compatible logger. Solves `missing _msg field` error in plugin server logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched to Victoria Metrics–compatible structured JSON request logging for HTTP requests.
  * Server now accepts an external logger instance to standardize log context and output.

* **Refactor**
  * Centralized request logging and adjusted initialization to produce consistent, structured request logs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->