### PR TITLE
Add 'immediate' field to PluginPolicy

### DIFF
--- a/internal/storage/postgres/policy.go
+++ b/internal/storage/postgres/policy.go
@@ -224,9 +224,9 @@ func (p *PostgresBackend) GetAllPluginPolicies(ctx context.Context, publicKey st
 func (p *PostgresBackend) InsertPluginPolicyTx(ctx context.Context, dbTx pgx.Tx, policy types.PluginPolicy) (*types.PluginPolicy, error) {
 	query := `
   	INSERT INTO plugin_policies (
-      id, public_key, plugin_id, plugin_version, policy_version, signature, active, recipe, immediate
+      id, public_key, plugin_id, plugin_version, policy_version, signature, active, recipe, immediate_start
     ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-    RETURNING id, public_key, plugin_id, plugin_version, policy_version, signature, active, recipe, immediate
+    RETURNING id, public_key, plugin_id, plugin_version, policy_version, signature, active, recipe, immediate_start
 	`
 
 	var insertedPolicy types.PluginPolicy
@@ -240,7 +240,7 @@ func (p *PostgresBackend) InsertPluginPolicyTx(ctx context.Context, dbTx pgx.Tx,
 		policy.Signature,
 		policy.Active,
 		policy.Recipe,
-		policy.Immediate,
+		policy.ImmediateStart,
 	).Scan(
 		&insertedPolicy.ID,
 		&insertedPolicy.PublicKey,
@@ -250,7 +250,7 @@ func (p *PostgresBackend) InsertPluginPolicyTx(ctx context.Context, dbTx pgx.Tx,
 		&insertedPolicy.Signature,
 		&insertedPolicy.Active,
 		&insertedPolicy.Recipe,
-		&insertedPolicy.Immediate,
+		&insertedPolicy.ImmediateStart,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to insert policy: %w", err)

--- a/plugin/policy/policy_pg/repo.go
+++ b/plugin/policy/policy_pg/repo.go
@@ -97,9 +97,9 @@ func (r *Repo) GetAllPluginPolicies(ctx context.Context, publicKey string, plugi
 func (r *Repo) InsertPluginPolicy(ctx context.Context, policy types.PluginPolicy) (*types.PluginPolicy, error) {
 	query := `
   	INSERT INTO plugin_policies (
-      id, public_key, plugin_id, plugin_version, policy_version, signature, active, recipe, immediate
+      id, public_key, plugin_id, plugin_version, policy_version, signature, active, recipe, immediate_start
     ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-    RETURNING id, public_key,  plugin_id, plugin_version, policy_version, signature, active, recipe, immediate
+    RETURNING id, public_key,  plugin_id, plugin_version, policy_version, signature, active, recipe, immediate_start
 	`
 
 	var insertedPolicy types.PluginPolicy
@@ -112,7 +112,7 @@ func (r *Repo) InsertPluginPolicy(ctx context.Context, policy types.PluginPolicy
 		policy.Signature,
 		policy.Active,
 		policy.Recipe,
-		policy.Immediate,
+		policy.ImmediateStart,
 	).Scan(
 		&insertedPolicy.ID,
 		&insertedPolicy.PublicKey,
@@ -122,7 +122,7 @@ func (r *Repo) InsertPluginPolicy(ctx context.Context, policy types.PluginPolicy
 		&insertedPolicy.Signature,
 		&insertedPolicy.Active,
 		&insertedPolicy.Recipe,
-		&insertedPolicy.Immediate,
+		&insertedPolicy.ImmediateStart,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to insert policy: %w", err)

--- a/types/policy.go
+++ b/types/policy.go
@@ -39,8 +39,8 @@ type PluginPolicy struct {
 	Recipe        string          `json:"recipe" validate:"required"`  // base64 encoded recipe protobuf bytes
 	Billing       []BillingPolicy `json:"billing" validate:"required"` // This will be populated later
 	//TODO: Add Immediate to policy signature verification in both FE and BE
-	Immediate bool `json:"immediate" validate:"required"`
-	Active    bool `json:"active" validate:"required"`
+	ImmediateStart bool `json:"immediate_start" validate:"required"`
+	Active         bool `json:"active" validate:"required"`
 }
 
 func (p *PluginPolicy) GetRecipe() (*rtypes.Policy, error) {


### PR DESCRIPTION
Releated issue: https://github.com/vultisig/recipes/issues/293

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin policies now support an "immediate" execution mode (a required flag) so policies can be applied right away when configured.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->