### PR TITLE
api: validate plugin request ID against API key

### DIFF
--- a/internal/api/plugin.go
+++ b/internal/api/plugin.go
@@ -46,7 +46,7 @@ func (s *Server) SignPluginMessages(c echo.Context) error {
 	// This prevents a malicious plugin from impersonating another plugin
 	authenticatedPluginID, ok := c.Get("plugin_id").(vtypes.PluginID)
 	if !ok {
-		return c.JSON(http.StatusUnauthorized, NewErrorResponseWithMessage("plugin authentication required"))
+		return c.JSON(http.StatusBadRequest, NewErrorResponseWithMessage(msgRequiredPluginID))
 	}
 	if authenticatedPluginID.String() != req.PluginID {
 		s.logger.Warnf("Plugin ID mismatch: authenticated=%s, requested=%s", authenticatedPluginID, req.PluginID)


### PR DESCRIPTION
Presently, if a plugin knows policy IDs belonging to other plugins it could: 

1. Submit a signing request for a policy owned by another plugin
2. Submit a signing request against the default fee policy

This is because while we validate (for non-fee plugins) that the `PluginID` in the request body matches the `PluginID` in the db policy, we do not validate that the plugin API key being used is actually assigned to that same plugin.

This fixes that by checking that the requesting API key matches the provided `PluginID`.

This is safer as:

1. For fee policy txs, only the fee plugin can invoke this now
2. For other plugins, only the plugin can submit a request - even if they lie about the policy ID, it will be caught further down by 

```go
// Validate policy matches plugin
if policy.PluginID != vtypes.PluginID(req.PluginID) {
	return fmt.Errorf("policy plugin ID mismatch")
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened plugin authentication for message-signing operations: the system now verifies plugin identity before signing messages, preventing unauthorized plugin impersonation and improving overall security.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->