### PR TITLE
go-wrappers upgrade

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       - name: Install Clang
         run: sudo apt-get install -y clang

--- a/.github/workflows/plugin-smoke-tests.yaml
+++ b/.github/workflows/plugin-smoke-tests.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.2'
+          go-version: '1.25.5'
 
       - name: Build plugin smoke test
         run: go build -o plugin-smoke-test testdata/plugin-smoke-test/main.go

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.2'
+          go-version: '1.25.5'
 
       - name: Download go-wrappers
         run: |

--- a/Dockerfile.dev.verifier
+++ b/Dockerfile.dev.verifier
@@ -1,5 +1,5 @@
 # Use the official Go image as the base image
-FROM golang:1.24
+FROM golang:1.25
 
 # Install air for hot reloading
 RUN go install github.com/air-verse/air@latest

--- a/Dockerfile.dev.worker
+++ b/Dockerfile.dev.worker
@@ -1,5 +1,5 @@
 # Use the official Go image as the base image
-FROM golang:1.24
+FROM golang:1.25
 
 # Install air for hot reloading
 RUN go install github.com/air-verse/air@latest

--- a/Dockerfile.k8s
+++ b/Dockerfile.k8s
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.24.2 AS builder
+FROM --platform=linux/amd64 golang:1.25.5 AS builder
 
 RUN apt-get update && apt-get install -y clang lld wget
 

--- a/Dockerfile.verifier
+++ b/Dockerfile.verifier
@@ -1,5 +1,5 @@
 # Use the official Go image as the base image
-FROM golang:1.24 AS builder
+FROM golang:1.25 AS builder
 
 # Set the working directory
 WORKDIR /app

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,5 +1,5 @@
 # Use the official Go image as the base image
-FROM golang:1.24 AS builder
+FROM golang:1.25 AS builder
 
 # Set the working directory
 WORKDIR /app

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vultisig/verifier
 
-go 1.24.2
+go 1.25
 
 require (
 	github.com/aws/aws-sdk-go v1.55.7
@@ -30,7 +30,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/swaggo/swag v1.16.4
 	github.com/vultisig/commondata v0.0.0-20250710214228-61d9ed8f7778
-	github.com/vultisig/go-wrappers v0.0.0-20250716071337-34a5c0f4d6e0
+	github.com/vultisig/go-wrappers v0.0.0-20260106233302-7e12f0dd6a93
 	github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74
 	github.com/vultisig/recipes v0.0.0-20260106090536-1198eaa21228
 	github.com/vultisig/vultiserver v0.0.0-20250825042420-c6e6ac281110

--- a/go.sum
+++ b/go.sum
@@ -1035,6 +1035,8 @@ github.com/vultisig/commondata v0.0.0-20250710214228-61d9ed8f7778 h1:XJ1hoo37JKG
 github.com/vultisig/commondata v0.0.0-20250710214228-61d9ed8f7778/go.mod h1:UMc5q0Myab+BvzAe67UQrXTXwKGYNxK7bky7DJM+dl8=
 github.com/vultisig/go-wrappers v0.0.0-20250716071337-34a5c0f4d6e0 h1:EdgQHZjzkY2nAhxr99zgbcs+3/8U1t6XW7ETiBEAr80=
 github.com/vultisig/go-wrappers v0.0.0-20250716071337-34a5c0f4d6e0/go.mod h1:UfGCxUQW08kiwxyNBiHwXe+ePPuBmHVVS+BS51aU/Jg=
+github.com/vultisig/go-wrappers v0.0.0-20260106233302-7e12f0dd6a93 h1:gQr4sjxsRr8MzdgPB/HEVK2bHg/vOhV/H+igsYbYPz8=
+github.com/vultisig/go-wrappers v0.0.0-20260106233302-7e12f0dd6a93/go.mod h1:vEP0x0RmNlghWxfalt13FvVsBwmobSwimMhJxGfqCD4=
 github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74 h1:goqwk4nQ/NEVIb3OPP9SUx7/u9ZfsUIcd5fIN/e4DVU=
 github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74/go.mod h1:nOykk4nOy1L3yXtLSlYvVsgizBnCQ3tR2N5uwGPdvaM=
 github.com/vultisig/recipes v0.0.0-20260106090536-1198eaa21228 h1:oSre0VkV9oIuQL579QbyP/8AGQVC7UMjvaMBkPD0Gzg=


### PR DESCRIPTION
Since go-wrappers have 1.25 version of Go we need to upgrade all plugins

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Go toolchain to version 1.25 across build workflows and container environments.
  * Updated supporting dependencies for compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->