### PR TITLE
feat: publish verifier images on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,47 @@
+name: Build and Release to GHCR
+
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-verifier:
+    uses: ./.github/workflows/build-push-image.yaml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      service: verifier
+      registry: ghcr.io
+      image_name: ${{ github.repository }}
+      tag: ${{ github.event.release.tag_name }}
+      additional_tag: latest
+      proposed_yaml: proposed.yaml
+
+  build-worker:
+    uses: ./.github/workflows/build-push-image.yaml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      service: worker
+      registry: ghcr.io
+      image_name: ${{ github.repository }}
+      tag: ${{ github.event.release.tag_name }}
+      additional_tag: latest
+
+  build-tx-indexer:
+    uses: ./.github/workflows/build-push-image.yaml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      service: tx_indexer
+      registry: ghcr.io
+      image_name: ${{ github.repository }}
+      tag: ${{ github.event.release.tag_name }}
+      additional_tag: latest


### PR DESCRIPTION
## Summary
- add release workflow to build/push verifier, worker, tx-indexer images to GHCR

## Test plan
- not run (CI workflow change only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GitHub Actions workflow to automate Docker image building and publishing for multiple services upon release events. Workflow builds and tags images for verifier, worker, and tx_indexer services, pushing them to the container registry.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->