### PR TITLE
fix: remove set-public job from release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,18 +52,6 @@ jobs:
       tag: ${{ inputs.tag || github.event.release.tag_name }}
       additional_tag: latest
 
-  set-public:
-    needs: [build-verifier, build-worker, build-tx-indexer]
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-    steps:
-      - name: Set GHCR packages public
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          owner="${{ github.repository_owner }}"
-          repo="${{ github.event.repository.name }}"
-          gh api -X PATCH "/orgs/${owner}/packages/container/${repo}%2Fverifier/visibility" -f visibility=public
-          gh api -X PATCH "/orgs/${owner}/packages/container/${repo}%2Fworker/visibility" -f visibility=public
-          gh api -X PATCH "/orgs/${owner}/packages/container/${repo}%2Ftx_indexer/visibility" -f visibility=public
+# NOTE: Package visibility must be set manually via GitHub UI.
+# GitHub's REST API does not support changing package visibility.
+# Go to: https://github.com/orgs/vultisig/packages → Package Settings → Change visibility to Public


### PR DESCRIPTION
## Summary
- Remove `set-public` job from release workflow - GitHub's REST API does not support changing package visibility
- Add comment explaining that visibility must be set manually via GitHub web UI

## Background
The `set-public` job was failing with 404 errors because GitHub's REST API does not provide an endpoint to change container package visibility. This is a known limitation - visibility changes must be done through the GitHub web UI.

## Manual step required
After first release, set package visibility to public via:
https://github.com/orgs/vultisig/packages → Package Settings → Change visibility to Public

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to require manual package visibility configuration via the GitHub UI instead of automated setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->