### PR TITLE
feat: add THORChain indexer for tx hash computation

### DIFF
--- a/plugin/tx_indexer/chains_list.go
+++ b/plugin/tx_indexer/chains_list.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/vultisig/recipes/sdk/btc"
+	cosmossdk "github.com/vultisig/recipes/sdk/cosmos"
 	"github.com/vultisig/recipes/sdk/solana"
 	"github.com/vultisig/recipes/sdk/xrpl"
 	"github.com/vultisig/verifier/plugin/tx_indexer/pkg/chain"
@@ -115,6 +116,10 @@ func Chains() (SupportedChains, error) {
 	))
 
 	chains[common.XRP] = chain.NewXRPIndexer(xrpl.NewSDK(
+		nil,
+	))
+
+	chains[common.THORChain] = chain.NewTHORChainIndexer(cosmossdk.NewSDK(
 		nil,
 	))
 

--- a/plugin/tx_indexer/pkg/chain/thorchain.go
+++ b/plugin/tx_indexer/pkg/chain/thorchain.go
@@ -1,0 +1,25 @@
+package chain
+
+import (
+	"fmt"
+
+	"github.com/vultisig/mobile-tss-lib/tss"
+	cosmossdk "github.com/vultisig/recipes/sdk/cosmos"
+)
+
+type THORChainIndexer struct {
+	sdk *cosmossdk.SDK
+}
+
+func NewTHORChainIndexer(sdk *cosmossdk.SDK) *THORChainIndexer {
+	return &THORChainIndexer{
+		sdk: sdk,
+	}
+}
+
+func (t *THORChainIndexer) ComputeTxHash(proposedTx []byte, sigs map[string]tss.KeysignResponse) (string, error) {
+	if t.sdk == nil {
+		return "", fmt.Errorf("sdk not initialized")
+	}
+	return t.sdk.ComputeTxHash(proposedTx), nil
+}

--- a/plugin/tx_indexer/pkg/chain/thorchain_test.go
+++ b/plugin/tx_indexer/pkg/chain/thorchain_test.go
@@ -1,0 +1,44 @@
+package chain
+
+import (
+	"testing"
+
+	"github.com/vultisig/mobile-tss-lib/tss"
+	cosmossdk "github.com/vultisig/recipes/sdk/cosmos"
+)
+
+func TestTHORChainIndexer_ComputeTxHash(t *testing.T) {
+	sdk := cosmossdk.NewSDK(nil)
+	indexer := NewTHORChainIndexer(sdk)
+
+	testTx := []byte{0x0a, 0x01, 0x02, 0x03}
+	sigs := map[string]tss.KeysignResponse{}
+
+	hash, err := indexer.ComputeTxHash(testTx, sigs)
+	if err != nil {
+		t.Fatalf("ComputeTxHash failed: %v", err)
+	}
+
+	if hash == "" {
+		t.Error("Expected non-empty hash")
+	}
+
+	expectedLen := 64
+	if len(hash) != expectedLen {
+		t.Errorf("Expected hash length %d, got %d", expectedLen, len(hash))
+	}
+
+	t.Logf("TX Hash: %s", hash)
+}
+
+func TestTHORChainIndexer_NilSDK(t *testing.T) {
+	indexer := NewTHORChainIndexer(nil)
+
+	testTx := []byte{0x0a, 0x01, 0x02, 0x03}
+	sigs := map[string]tss.KeysignResponse{}
+
+	_, err := indexer.ComputeTxHash(testTx, sigs)
+	if err == nil {
+		t.Error("Expected error for nil SDK")
+	}
+}


### PR DESCRIPTION
Enables tx_indexer to compute transaction hashes for THORChain (RUNE) swaps, supporting the RUNE swap feature in app-recurring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added THORChain support to the transaction indexer with the ability to compute transaction hashes for THORChain transactions.

* **Tests**
  * Added comprehensive unit tests to validate THORChain functionality and error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->