### PR TITLE
define router

### DIFF
--- a/plugin/server/server.go
+++ b/plugin/server/server.go
@@ -97,7 +97,7 @@ func (s *Server) taskQueueName() string {
 	return tasks.QUEUE_NAME
 }
 
-func (s *Server) Start(ctx context.Context) error {
+func (s *Server) GetRouter() *echo.Echo {
 	e := echo.New()
 
 	// Prepare middlewares slice with optional metrics middleware
@@ -128,6 +128,12 @@ func (s *Server) Start(ctx context.Context) error {
 	plg.POST("/recipe-specification/suggest", s.handleGetRecipeSpecificationSuggest)
 	plg.DELETE("/policy/:policyId", s.handleDeletePluginPolicyById, s.VerifierAuthMiddleware)
 	plg.PUT("/safety", s.handleSyncSafety, s.VerifierAuthMiddleware)
+
+	return e
+}
+
+func (s *Server) Start(ctx context.Context) error {
+	e := s.GetRouter()
 
 	eg := &errgroup.Group{}
 	eg.Go(func() error {


### PR DESCRIPTION
Refactor: Expose Echo router for service extensibility

Adds GetRouter() method to enable downstream services to extend the server with custom endpoints and route groups. Refactors Start() to use GetRouter() internally, maintaining backward compatibility.

Changes:
- Add GetRouter() *echo.Echo method
- Refactor Start() to use GetRouter()
- No breaking changes to existing API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal server architecture by reorganizing router initialization for enhanced code organization and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->