### PR TITLE
implemented access token and refresh token logic

### DIFF
--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/labstack/echo/v4"
+
+	"github.com/vultisig/verifier/internal/service"
 )
 
 func (s *Server) AuthMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
@@ -57,6 +59,11 @@ func (s *Server) VaultAuthMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 		if err != nil {
 			s.logger.Warnf("fail to validate token, err: %v", err)
 			return c.JSON(http.StatusUnauthorized, NewErrorResponseWithMessage(msgUnauthorized))
+		}
+
+		if claims.TokenType != service.TokenTypeAccess {
+			s.logger.Warnf("invalid token type: expected access token, got: %s", claims.TokenType)
+			return c.JSON(http.StatusUnauthorized, NewErrorResponseWithMessage("access token required"))
 		}
 
 		// Get requested vault's public key from URL parameter


### PR DESCRIPTION
before:
{
    "data": {
        "token": "<token>"
     },
    ...
} 
now:
{
    "data": {
        "access_token": "<token>",
        "refresh_token": "<token>",
        "expires_in": 3600
    },
    ...
} 
Closes [recipes/#474](https://github.com/vultisig/recipes/issues/474)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented dual-token authentication with separate access and refresh tokens for enhanced security and improved session management.
  * Made the token refresh endpoint publicly accessible, enabling users to refresh their authentication tokens without prior authorization.

* **Bug Fixes**
  * Strengthened token type validation to prevent unauthorized token usage.
  * Improved token lifecycle management and validation workflows during authentication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->