### PR TITLE
Simplify release tags: use vX.X.X instead of release/vX.X.X

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,7 +3,7 @@ name: Deploy Verifier Server
 on:
   push:
     branches: ['main']
-    tags: ['release/*']
+    tags: ['v*']
   pull_request:
     branches: ['main']
 
@@ -69,7 +69,7 @@ jobs:
           go build -o portal cmd/portal/main.go
   deploy-production:
     needs: [test, build]
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/release/')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     environment: production
     runs-on: ubuntu-22.04
     steps:
@@ -90,7 +90,7 @@ jobs:
           ./scripts/deploy.sh
   deploy-portal:
     needs: [test, build]
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/release/')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     environment: production
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
## Summary
- Changed deploy.yaml to trigger on `v*` tags instead of `release/*`
- Docker image tags like `release/v0.1.18` were invalid (can't contain `/`)
- Now use simple `vX.X.X` tags for everything

## New deployment process
```bash
git tag v0.1.19
git push origin v0.1.19
```

This will trigger both:
1. Production deployment (deploy.yaml)
2. Docker image builds when a GitHub Release is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow configuration for internal release processes. Tag-based deployment triggers have been modified to align with new versioning conventions. No changes to user-facing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->