### PR TITLE
fix: trigger dev deployment when syncing main to dev

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -8,6 +8,7 @@ on:
       - '**.md'
       - '.gitignore'
       - 'LICENSE'
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/sync-main-to-dev.yaml
+++ b/.github/workflows/sync-main-to-dev.yaml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -24,3 +25,8 @@ jobs:
           git checkout dev
           git merge origin/main --no-edit
           git push origin dev
+
+      - name: Trigger dev deployment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run deploy-dev.yaml --ref dev


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to `deploy-dev.yaml`
- Call `gh workflow run deploy-dev.yaml --ref dev` from `sync-main-to-dev.yaml` after pushing to dev branch
- Add `actions: write` permission to allow triggering workflows

This works around GitHub Actions limitation where pushes made with `GITHUB_TOKEN` don't trigger other workflows.

## Test plan
- [ ] Merge this PR to main
- [ ] Verify that sync-main-to-dev triggers deploy-dev workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)