### PR TITLE
refactor: remove ::plugin_id casts from earnings queries

### DIFF
--- a/internal/storage/postgres/queries/earnings.sql.go
+++ b/internal/storage/postgres/queries/earnings.sql.go
@@ -14,7 +14,7 @@ import (
 const countEarningsByPluginOwnerFiltered = `-- name: CountEarningsByPluginOwnerFiltered :one
 SELECT COUNT(DISTINCT f.id)::bigint as total
 FROM fees f
-JOIN plugins p ON f.plugin_id::plugin_id = p.id
+JOIN plugins p ON f.plugin_id = p.id::text
 LEFT JOIN plugin_policies pp ON f.policy_id = pp.id
 LEFT JOIN plugin_policy_billing ppb ON pp.id = ppb.plugin_policy_id
 LEFT JOIN tx_indexer ti ON f.policy_id = ti.policy_id
@@ -101,7 +101,7 @@ SELECT
         ELSE 'pending'
     END as status
 FROM fees f
-JOIN plugins p ON f.plugin_id::plugin_id = p.id
+JOIN plugins p ON f.plugin_id = p.id::text
 LEFT JOIN plugin_policies pp ON f.policy_id = pp.id
 LEFT JOIN plugin_policy_billing ppb ON pp.id = ppb.plugin_policy_id
 LEFT JOIN tx_indexer ti ON f.policy_id = ti.policy_id
@@ -174,7 +174,7 @@ SELECT
         ELSE 'pending'
     END as status
 FROM fees f
-JOIN plugins p ON f.plugin_id::plugin_id = p.id
+JOIN plugins p ON f.plugin_id = p.id::text
 LEFT JOIN plugin_policies pp ON f.policy_id = pp.id
 LEFT JOIN plugin_policy_billing ppb ON pp.id = ppb.plugin_policy_id
 LEFT JOIN tx_indexer ti ON f.policy_id = ti.policy_id

--- a/internal/storage/postgres/sqlc/earnings.sql
+++ b/internal/storage/postgres/sqlc/earnings.sql
@@ -17,7 +17,7 @@ SELECT
         ELSE 'pending'
     END as status
 FROM fees f
-JOIN plugins p ON f.plugin_id::plugin_id = p.id
+JOIN plugins p ON f.plugin_id = p.id::text
 LEFT JOIN plugin_policies pp ON f.policy_id = pp.id
 LEFT JOIN plugin_policy_billing ppb ON pp.id = ppb.plugin_policy_id
 LEFT JOIN tx_indexer ti ON f.policy_id = ti.policy_id
@@ -44,7 +44,7 @@ SELECT
         ELSE 'pending'
     END as status
 FROM fees f
-JOIN plugins p ON f.plugin_id::plugin_id = p.id
+JOIN plugins p ON f.plugin_id = p.id::text
 LEFT JOIN plugin_policies pp ON f.policy_id = pp.id
 LEFT JOIN plugin_policy_billing ppb ON pp.id = ppb.plugin_policy_id
 LEFT JOIN tx_indexer ti ON f.policy_id = ti.policy_id
@@ -61,7 +61,7 @@ LIMIT $5 OFFSET $6;
 -- name: CountEarningsByPluginOwnerFiltered :one
 SELECT COUNT(DISTINCT f.id)::bigint as total
 FROM fees f
-JOIN plugins p ON f.plugin_id::plugin_id = p.id
+JOIN plugins p ON f.plugin_id = p.id::text
 LEFT JOIN plugin_policies pp ON f.policy_id = pp.id
 LEFT JOIN plugin_policy_billing ppb ON pp.id = ppb.plugin_policy_id
 LEFT JOIN tx_indexer ti ON f.policy_id = ti.policy_id


### PR DESCRIPTION
## Summary
- Change `f.plugin_id::plugin_id = p.id` to `f.plugin_id = p.id::text` in 3 earnings queries
- This makes queries safe for both the current enum type and a future text type
- Casts the enum PK to text (valid on enums) instead of casting varchar to the enum type

## Context
This is **Branch 1** of a two-part migration to convert `plugin_id` from a PostgreSQL ENUM to plain TEXT. Deploy this first — it's backward-compatible with the current enum schema.

**Branch 2:** #547 (`plugin-id-enum-to-text`) — runs the actual migration, stacked on this branch.

## Test plan
- [ ] `go build ./...` passes
- [ ] Earnings/plugins queries work against the existing enum schema
- [ ] Deploy to staging and verify earnings endpoints return correct data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected earnings retrieval so plugin owner payouts display consistently by aligning how plugin identifiers are compared across related queries, resolving intermittent mismatches and ensuring accurate totals and listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->