### PR TITLE
chore: use kubeconfig instead of doctl for dev deployment

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -13,7 +13,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  CLUSTER: plugins-dev-k8s
   NS: verifier
 
 jobs:
@@ -74,13 +73,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install doctl
-        uses: digitalocean/action-doctl@v2
-        with:
-          token: ${{ secrets.DIGITALOCEAN_CI_TOKEN }}
-
-      - name: Save DigitalOcean kubeconfig
-        run: doctl kubernetes cluster kubeconfig save ${{ env.CLUSTER }}
+      - name: Set up kubeconfig
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.KUBECONFIG_DEV }}" > ~/.kube/config
+          chmod 600 ~/.kube/config
 
       - name: Update deployment files
         run: |


### PR DESCRIPTION
## Summary
- Replace `secrets.DIGITALOCEAN_CI_TOKEN` with `secrets.KUBECONFIG_DEV` (base64 encoded kubeconfig) for dev deployment

## Changes
- `.github/workflows/deploy-dev.yaml`: Removed doctl installation, use kubeconfig secret directly

## Test plan
- [ ] Add `KUBECONFIG_DEV` secret to repo (base64 encoded kubeconfig)
- [ ] Verify dev deployment works on push to `dev` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow to use secret-based kubeconfig configuration, removing dependency on external tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->