### PR TITLE
feat(cosmos): add MsgBeginRedelegate + MsgWithdrawDelegatorReward schemas

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/hibiken/asynq v0.25.1
+	github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6
 	github.com/jackc/pgx/v5 v5.7.4
 	github.com/kaptinlin/jsonschema v0.4.6
 	github.com/kelseyhightower/envconfig v1.4.0
@@ -31,7 +32,7 @@ require (
 	github.com/vultisig/commondata v0.0.0-20250710214228-61d9ed8f7778
 	github.com/vultisig/go-wrappers v0.0.0-20260116015747-e12e4d06cf57
 	github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74
-	github.com/vultisig/recipes v0.0.0-20260129020926-577976dfb292
+	github.com/vultisig/recipes v0.0.0-20260430070612-989f77eca639
 	github.com/vultisig/vultiserver v0.0.0-20250825042420-c6e6ac281110
 	github.com/vultisig/vultisig-go v0.0.0-20260114092710-6c38516a0c85
 	github.com/xyield/xrpl-go v0.0.0-20230914223425-9abe75c05830
@@ -177,7 +178,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/ipfs/go-log v1.0.5 // indirect
 	github.com/ipfs/go-log/v2 v2.5.1 // indirect
-	github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,11 @@ module github.com/vultisig/verifier
 go 1.25
 
 require (
+	cosmossdk.io/math v1.5.3
 	github.com/aws/aws-sdk-go v1.55.7
 	github.com/btcsuite/btcd v0.24.2
 	github.com/btcsuite/btcd/btcutil/psbt v1.1.10
+	github.com/cosmos/cosmos-sdk v0.50.11
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0
 	github.com/eager7/dogd v0.0.0-20200427085516-2caf59f59dbb
 	github.com/ethereum/go-ethereum v1.15.11
@@ -32,7 +34,7 @@ require (
 	github.com/vultisig/commondata v0.0.0-20250710214228-61d9ed8f7778
 	github.com/vultisig/go-wrappers v0.0.0-20260116015747-e12e4d06cf57
 	github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74
-	github.com/vultisig/recipes v0.0.0-20260430070612-989f77eca639
+	github.com/vultisig/recipes v0.0.0-20260430121755-475ad1fe90db
 	github.com/vultisig/vultiserver v0.0.0-20250825042420-c6e6ac281110
 	github.com/vultisig/vultisig-go v0.0.0-20260114092710-6c38516a0c85
 	github.com/xyield/xrpl-go v0.0.0-20230914223425-9abe75c05830
@@ -49,7 +51,6 @@ require (
 	cosmossdk.io/depinject v1.2.1 // indirect
 	cosmossdk.io/errors v1.0.2 // indirect
 	cosmossdk.io/log v1.6.0 // indirect
-	cosmossdk.io/math v1.5.3 // indirect
 	cosmossdk.io/schema v1.1.0 // indirect
 	cosmossdk.io/store v1.1.2 // indirect
 	cosmossdk.io/x/tx v0.14.0 // indirect
@@ -95,7 +96,6 @@ require (
 	github.com/cosmos/btcutil v1.0.5 // indirect
 	github.com/cosmos/cosmos-db v1.1.1 // indirect
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5 // indirect
-	github.com/cosmos/cosmos-sdk v0.50.11 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cosmos/gogogateway v1.2.0 // indirect
 	github.com/cosmos/gogoproto v1.7.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/vultisig/commondata v0.0.0-20250710214228-61d9ed8f7778
 	github.com/vultisig/go-wrappers v0.0.0-20260116015747-e12e4d06cf57
 	github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74
-	github.com/vultisig/recipes v0.0.0-20260430121755-475ad1fe90db
+	github.com/vultisig/recipes v0.0.0-20260503115421-d28b3880fd08
 	github.com/vultisig/vultiserver v0.0.0-20250825042420-c6e6ac281110
 	github.com/vultisig/vultisig-go v0.0.0-20260114092710-6c38516a0c85
 	github.com/xyield/xrpl-go v0.0.0-20230914223425-9abe75c05830

--- a/go.sum
+++ b/go.sum
@@ -1046,8 +1046,8 @@ github.com/vultisig/go-wrappers v0.0.0-20260116015747-e12e4d06cf57 h1:ZFlNC4JuaY
 github.com/vultisig/go-wrappers v0.0.0-20260116015747-e12e4d06cf57/go.mod h1:vEP0x0RmNlghWxfalt13FvVsBwmobSwimMhJxGfqCD4=
 github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74 h1:goqwk4nQ/NEVIb3OPP9SUx7/u9ZfsUIcd5fIN/e4DVU=
 github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74/go.mod h1:nOykk4nOy1L3yXtLSlYvVsgizBnCQ3tR2N5uwGPdvaM=
-github.com/vultisig/recipes v0.0.0-20260129020926-577976dfb292 h1:CVXtJBOjJfzMsv+akQK65Jcup9/TSeMUXD8NMJ9O0eg=
-github.com/vultisig/recipes v0.0.0-20260129020926-577976dfb292/go.mod h1:PUz2BoPkuCrk9EFeWavynFSIMM2DNULfFeSS0CGVIVc=
+github.com/vultisig/recipes v0.0.0-20260430070612-989f77eca639 h1:brVx7S9gELCbDP0xaTqx/sCMkwNvGSdXPcsO+hr3ahs=
+github.com/vultisig/recipes v0.0.0-20260430070612-989f77eca639/go.mod h1:PUz2BoPkuCrk9EFeWavynFSIMM2DNULfFeSS0CGVIVc=
 github.com/vultisig/vultiserver v0.0.0-20250825042420-c6e6ac281110 h1:7WDQ92FAdu08Byjgm3RNS8Sok49sK521PzPcbRpbzCE=
 github.com/vultisig/vultiserver v0.0.0-20250825042420-c6e6ac281110/go.mod h1:HwP2IgW6Mcu/gX8paFuKvfibrGE9UmPgkOFTub6dskM=
 github.com/vultisig/vultisig-go v0.0.0-20260114092710-6c38516a0c85 h1:NAVXp2Mm791Z/teQHUA8T7mhmx3bouyrXvQkLXvAu3M=

--- a/go.sum
+++ b/go.sum
@@ -1048,6 +1048,8 @@ github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74 h1:goqwk4n
 github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74/go.mod h1:nOykk4nOy1L3yXtLSlYvVsgizBnCQ3tR2N5uwGPdvaM=
 github.com/vultisig/recipes v0.0.0-20260430121755-475ad1fe90db h1:hYjpUTaFVqJWVWF7+/RyZNI81C5uG7Q6Q0rm2IS8hf0=
 github.com/vultisig/recipes v0.0.0-20260430121755-475ad1fe90db/go.mod h1:PUz2BoPkuCrk9EFeWavynFSIMM2DNULfFeSS0CGVIVc=
+github.com/vultisig/recipes v0.0.0-20260503115421-d28b3880fd08 h1:GiZ9OfXAJst6+9ee73QxxfSqItbWB6HhmDQ79lx//cc=
+github.com/vultisig/recipes v0.0.0-20260503115421-d28b3880fd08/go.mod h1:PUz2BoPkuCrk9EFeWavynFSIMM2DNULfFeSS0CGVIVc=
 github.com/vultisig/vultiserver v0.0.0-20250825042420-c6e6ac281110 h1:7WDQ92FAdu08Byjgm3RNS8Sok49sK521PzPcbRpbzCE=
 github.com/vultisig/vultiserver v0.0.0-20250825042420-c6e6ac281110/go.mod h1:HwP2IgW6Mcu/gX8paFuKvfibrGE9UmPgkOFTub6dskM=
 github.com/vultisig/vultisig-go v0.0.0-20260114092710-6c38516a0c85 h1:NAVXp2Mm791Z/teQHUA8T7mhmx3bouyrXvQkLXvAu3M=

--- a/go.sum
+++ b/go.sum
@@ -1046,8 +1046,8 @@ github.com/vultisig/go-wrappers v0.0.0-20260116015747-e12e4d06cf57 h1:ZFlNC4JuaY
 github.com/vultisig/go-wrappers v0.0.0-20260116015747-e12e4d06cf57/go.mod h1:vEP0x0RmNlghWxfalt13FvVsBwmobSwimMhJxGfqCD4=
 github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74 h1:goqwk4nQ/NEVIb3OPP9SUx7/u9ZfsUIcd5fIN/e4DVU=
 github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74/go.mod h1:nOykk4nOy1L3yXtLSlYvVsgizBnCQ3tR2N5uwGPdvaM=
-github.com/vultisig/recipes v0.0.0-20260430070612-989f77eca639 h1:brVx7S9gELCbDP0xaTqx/sCMkwNvGSdXPcsO+hr3ahs=
-github.com/vultisig/recipes v0.0.0-20260430070612-989f77eca639/go.mod h1:PUz2BoPkuCrk9EFeWavynFSIMM2DNULfFeSS0CGVIVc=
+github.com/vultisig/recipes v0.0.0-20260430121755-475ad1fe90db h1:hYjpUTaFVqJWVWF7+/RyZNI81C5uG7Q6Q0rm2IS8hf0=
+github.com/vultisig/recipes v0.0.0-20260430121755-475ad1fe90db/go.mod h1:PUz2BoPkuCrk9EFeWavynFSIMM2DNULfFeSS0CGVIVc=
 github.com/vultisig/vultiserver v0.0.0-20250825042420-c6e6ac281110 h1:7WDQ92FAdu08Byjgm3RNS8Sok49sK521PzPcbRpbzCE=
 github.com/vultisig/vultiserver v0.0.0-20250825042420-c6e6ac281110/go.mod h1:HwP2IgW6Mcu/gX8paFuKvfibrGE9UmPgkOFTub6dskM=
 github.com/vultisig/vultisig-go v0.0.0-20260114092710-6c38516a0c85 h1:NAVXp2Mm791Z/teQHUA8T7mhmx3bouyrXvQkLXvAu3M=

--- a/plugin/tx_indexer/pkg/chain/cosmos_msg_types_test.go
+++ b/plugin/tx_indexer/pkg/chain/cosmos_msg_types_test.go
@@ -3,13 +3,15 @@ package chain
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
+	"strings"
 	"testing"
 
 	"cosmossdk.io/math"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	cosmostypes "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/tx"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/stretchr/testify/assert"
@@ -26,33 +28,67 @@ import (
 //     This is what consumers of `sdk.InterfaceRegistry()` (including downstream
 //     decoders that DO need to UnpackAny the body messages — e.g. anything
 //     that inspects the redelegate amount or validator addresses post-sign)
-//     rely on. We assert this directly via `UnpackAny` in
-//     TestRecipesSDKRegistersStakingDistributionInterfaces.
+//     rely on. We assert this directly via `UnpackAny` against an Any whose
+//     cachedValue has been cleared by a marshal+unmarshal roundtrip — that
+//     forces the registry resolution path rather than the cached fast-path.
 //
 //  2. The end-to-end indexer hash path (`Sign + ComputeTxHash`) accepts the
-//     new tx shapes and produces a stable SHA256 of the signed bytes. Note
-//     that Sign() itself only round-trips the outer tx.Tx envelope — it does
-//     not UnpackAny the body messages — so the hash tests don't *require*
-//     the new interface registrations to pass. They guard the broader
-//     contract: an indexer fed an unsigned redelegate/withdraw_rewards tx
-//     should not error, and the hash is shaped like all other cosmos hashes.
+//     new tx shapes and produces SHA256 of the signed bytes. Sign() itself
+//     does not UnpackAny the body messages — it round-trips the outer tx.Tx
+//     envelope — so the hash tests don't *require* the new interface
+//     registrations to pass. They guard the broader contract: an indexer fed
+//     an unsigned redelegate/withdraw_rewards tx (or a multi-msg body mixing
+//     bank + staking, or a thor MsgDeposit + cosmos staking msg) should not
+//     error, and the hash equals SHA256 of the marshalled signed bytes.
 //
 // If a future recipes bump regresses either invariant, the failure surfaces
 // here rather than at runtime when a real redelegate broadcasts.
 
+// Real-shape test fixtures.
+//
+// Addresses are real bech32 strings on cosmoshub-4. The delegator address
+// matches QA-Stability-Vault's cosmoshub address; the validator addresses are
+// well-known mainnet validators (Coinbase Custody, Binance Staking). These
+// addresses don't need to be live for tests — the SDK's Sign()/ComputeTxHash
+// path doesn't validate them — but using real shapes means a future bech32
+// stricter check upstream wouldn't fail in a confusing way.
 const (
-	testDelegator    = "cosmos1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-	testValidatorSrc = "cosmosvaloper1srcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-	testValidatorDst = "cosmosvaloper1dstxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-	testValidator    = "cosmosvaloper1abcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+	testDelegator    = "cosmos1n9qcqp4ds6c30zmnyxwq30vfd03cyuq3gpsllv"
+	testValidatorSrc = "cosmosvaloper1grgelyng2v6v3t8z87wu3sxgt9m5s03xfytvz7"
+	testValidatorDst = "cosmosvaloper1sjllsnramtg7ewxqwwrwjxfgc4n4ef9u2lcnj0"
+	testValidator    = "cosmosvaloper1grgelyng2v6v3t8z87wu3sxgt9m5s03xfytvz7"
+	testRecipient    = "cosmos1ej2es5fjztqjcd4pwa0zyvaevtjd2y5w37wr9t"
 )
 
-// fakeSig returns a 64-byte deterministic R || S split that the recipes SDK
-// will accept (low-S normalization happens inside Sign()).
-func fakeSig() tss.KeysignResponse {
+// testKeypair returns a deterministic secp256k1 keypair derived from a fixed
+// seed. The pubkey bytes are a real on-curve compressed (33-byte) secp256k1
+// point — not the off-curve `[0x02 || 32 zero-bytes]` placeholder we used in
+// the first cut. Sign() in recipes doesn't validate curve membership today,
+// but a stricter upstream check would reject the placeholder, so use a real
+// point.
+func testKeypair(t *testing.T) (*secp256k1.PrivKey, []byte) {
+	t.Helper()
+	priv := secp256k1.GenPrivKeyFromSecret([]byte("vultisig-verifier-cosmos-msg-types-test"))
+	pub := priv.PubKey().Bytes()
+	require.Len(t, pub, 33, "compressed secp256k1 pubkey must be 33 bytes")
+	require.True(t, pub[0] == 0x02 || pub[0] == 0x03, "valid compressed pubkey starts with 0x02 or 0x03")
+	return priv, pub
+}
+
+// testSig returns a real ECDSA signature over a deterministic message, split
+// into R || S hex strings as the recipes SDK expects on the wire from a TSS
+// keysign. The signature is in lower-S form (the secp256k1 Sign helper
+// normalizes it). This replaces the earlier 32-byte-zero R placeholder, which
+// would never come out of a real keysign.
+func testSig(t *testing.T, priv *secp256k1.PrivKey) tss.KeysignResponse {
+	t.Helper()
+	msg := []byte("vultisig-verifier-cosmos-msg-types-test-message")
+	sig, err := priv.Sign(msg)
+	require.NoError(t, err)
+	require.Len(t, sig, 64, "secp256k1 signature is R||S = 64 bytes")
 	return tss.KeysignResponse{
-		R: hex.EncodeToString(make([]byte, 32)),
-		S: hex.EncodeToString(append([]byte{0x01}, make([]byte, 31)...)),
+		R: hex.EncodeToString(sig[:32]),
+		S: hex.EncodeToString(sig[32:]),
 	}
 }
 
@@ -60,14 +96,18 @@ func fakeSig() tss.KeysignResponse {
 // SignerInfos (Sign() injects the signer info from the provided pubkey).
 // This mirrors the shape that vultisig-app's cosmosTx.ts emits before
 // keysign — the unsigned bytes the verifier indexer receives.
-func buildUnsignedCosmosTx(t *testing.T, msg cosmostypes.Msg) []byte {
+func buildUnsignedCosmosTx(t *testing.T, msgs ...cosmostypes.Msg) []byte {
 	t.Helper()
 
-	any, err := codectypes.NewAnyWithValue(msg)
-	require.NoError(t, err)
+	anys := make([]*codectypes.Any, 0, len(msgs))
+	for _, m := range msgs {
+		any, err := codectypes.NewAnyWithValue(m)
+		require.NoError(t, err)
+		anys = append(anys, any)
+	}
 
 	body := &tx.TxBody{
-		Messages: []*codectypes.Any{any},
+		Messages: anys,
 	}
 
 	authInfo := &tx.AuthInfo{
@@ -87,12 +127,49 @@ func buildUnsignedCosmosTx(t *testing.T, msg cosmostypes.Msg) []byte {
 	return bz
 }
 
+// expectedSignedHash signs the unsigned tx and returns the upper-hex SHA256
+// of the marshalled signed bytes — i.e. the exact value ComputeTxHash should
+// return. Callers use this to assert byte-for-byte equality with the indexer.
+func expectedSignedHash(t *testing.T, sdk *cosmossdk.SDK, unsigned []byte, sigs map[string]tss.KeysignResponse, pubKey []byte) string {
+	t.Helper()
+	signed, err := sdk.Sign(unsigned, sigs, pubKey)
+	require.NoError(t, err)
+	sum := sha256.Sum256(signed)
+	return strings.ToUpper(hex.EncodeToString(sum[:]))
+}
+
+// roundTripAny clears the cachedValue on an Any by marshalling and
+// unmarshalling, forcing UnpackAny to actually consult the InterfaceRegistry
+// rather than short-circuiting on the cached pointer. Without this, the
+// registry-registration assertion is a no-op: NewAnyWithValue stashes the
+// original *MsgBeginRedelegate on the Any, and UnpackAny just type-asserts
+// against the cached value — passing even if the registry doesn't know the
+// type URL at all.
+//
+// Reference: cosmos-sdk codec/types/interface_registry.go:UnpackAny — the
+// `cachedValue != nil` branch returns before any registry lookup.
+func roundTripAny(t *testing.T, original *codectypes.Any) *codectypes.Any {
+	t.Helper()
+	bz, err := original.Marshal()
+	require.NoError(t, err)
+	out := &codectypes.Any{}
+	require.NoError(t, out.Unmarshal(bz))
+	return out
+}
+
 // TestRecipesSDKRegistersStakingDistributionInterfaces asserts the actual
 // behavior change recipes Phase 1.5 introduces: a freshly-built recipes
 // Cosmos SDK can decode a /cosmos.staking.v1beta1.MsgBeginRedelegate and a
 // /cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward off the wire. This
 // is the load-bearing assertion for any verifier consumer that goes beyond
 // envelope round-tripping (e.g. policy evaluation, parameter extraction).
+//
+// We force the registry path by marshal+unmarshalling the Any first — see
+// roundTripAny — so the cachedValue fast-path can't mask a missing
+// registration. If you remove `stakingtypes.RegisterInterfaces(ir)` or
+// `distributiontypes.RegisterInterfaces(ir)` from
+// recipes/sdk/cosmos/sdk.go's NewSDK, this test fails with
+// "no registered implementations of type ... for type URL ...".
 func TestRecipesSDKRegistersStakingDistributionInterfaces(t *testing.T) {
 	sdk := cosmossdk.NewSDK(nil)
 	ir := sdk.InterfaceRegistry()
@@ -108,11 +185,19 @@ func TestRecipesSDKRegistersStakingDistributionInterfaces(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "/cosmos.staking.v1beta1.MsgBeginRedelegate", any.TypeUrl)
 
+		// Force the registry path; without this, UnpackAny would short-circuit
+		// on the cached *MsgBeginRedelegate that NewAnyWithValue stashed.
+		any = roundTripAny(t, any)
+
 		var decoded cosmostypes.Msg
 		err = ir.UnpackAny(any, &decoded)
 		require.NoError(t, err, "recipes SDK must register stakingtypes.RegisterInterfaces")
-		_, ok := decoded.(*stakingtypes.MsgBeginRedelegate)
-		assert.True(t, ok)
+		got, ok := decoded.(*stakingtypes.MsgBeginRedelegate)
+		require.True(t, ok)
+		assert.Equal(t, original.DelegatorAddress, got.DelegatorAddress)
+		assert.Equal(t, original.ValidatorSrcAddress, got.ValidatorSrcAddress)
+		assert.Equal(t, original.ValidatorDstAddress, got.ValidatorDstAddress)
+		assert.Equal(t, original.Amount, got.Amount)
 	})
 
 	t.Run("MsgWithdrawDelegatorReward decodes via SDK registry", func(t *testing.T) {
@@ -124,23 +209,47 @@ func TestRecipesSDKRegistersStakingDistributionInterfaces(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward", any.TypeUrl)
 
+		any = roundTripAny(t, any)
+
 		var decoded cosmostypes.Msg
 		err = ir.UnpackAny(any, &decoded)
 		require.NoError(t, err, "recipes SDK must register distributiontypes.RegisterInterfaces")
-		_, ok := decoded.(*distributiontypes.MsgWithdrawDelegatorReward)
-		assert.True(t, ok)
+		got, ok := decoded.(*distributiontypes.MsgWithdrawDelegatorReward)
+		require.True(t, ok)
+		assert.Equal(t, original.DelegatorAddress, got.DelegatorAddress)
+		assert.Equal(t, original.ValidatorAddress, got.ValidatorAddress)
 	})
 }
 
-func TestTHORChainIndexer_HashesMsgBeginRedelegate(t *testing.T) {
-	// Use the same wiring as chains_list.go: NewSDK with thor/maya types
-	// registered. With the recipes Phase 1.5 patch, NewSDK auto-registers
-	// staking + distribution interfaces too, so MsgBeginRedelegate decodes.
+// thorChainTestSDK builds an SDK wired the way chains_list.go wires the
+// THORChain indexer: NewSDK + thor MsgDeposit registration + RefreshCodec.
+// Tests that exercise THORChainIndexer use this so the codec sees both the
+// native cosmos staking/distribution types (registered by NewSDK) and
+// thor-specific ones (registered explicitly).
+func thorChainTestSDK() *cosmossdk.SDK {
 	sdk := cosmossdk.NewSDK(nil)
 	rtypes.RegisterInterfaces(sdk.InterfaceRegistry())
 	sdk.RefreshCodec()
+	return sdk
+}
 
+// mayaChainTestSDK mirrors thorChainTestSDK for the Maya indexer.
+// chains_list.go wires Maya with the same rtypes.RegisterInterfaces call, so
+// the test stack is identical — but the indexer struct and chain ID differ,
+// so we keep a distinct helper for clarity.
+func mayaChainTestSDK() *cosmossdk.SDK {
+	sdk := cosmossdk.NewSDK(nil)
+	rtypes.RegisterInterfaces(sdk.InterfaceRegistry())
+	sdk.RefreshCodec()
+	return sdk
+}
+
+func TestTHORChainIndexer_HashesMsgBeginRedelegate(t *testing.T) {
+	sdk := thorChainTestSDK()
 	indexer := NewTHORChainIndexer(sdk)
+	_, pubKey := testKeypair(t)
+	priv, _ := testKeypair(t)
+	sigs := map[string]tss.KeysignResponse{"signer-0": testSig(t, priv)}
 
 	msg := &stakingtypes.MsgBeginRedelegate{
 		DelegatorAddress:    testDelegator,
@@ -150,10 +259,6 @@ func TestTHORChainIndexer_HashesMsgBeginRedelegate(t *testing.T) {
 	}
 	unsigned := buildUnsignedCosmosTx(t, msg)
 
-	pubKey := make([]byte, 33)
-	pubKey[0] = 0x02
-	sigs := map[string]tss.KeysignResponse{"signer-0": fakeSig()}
-
 	hash, err := indexer.ComputeTxHash(unsigned, sigs, pubKey)
 	require.NoError(t, err, "indexer must accept MsgBeginRedelegate after recipes Phase 1.5")
 	assert.Len(t, hash, 64, "cosmos tx hash is uppercase hex SHA256 of signed bytes")
@@ -162,14 +267,20 @@ func TestTHORChainIndexer_HashesMsgBeginRedelegate(t *testing.T) {
 	hash2, err := indexer.ComputeTxHash(unsigned, sigs, pubKey)
 	require.NoError(t, err)
 	assert.Equal(t, hash, hash2)
+
+	// Byte-equality with SHA256(signed): the indexer's contract is exactly
+	// SHA256 of the marshalled signed tx bytes — this is what
+	// TestTHORChainIndexer_HashIsSignedShape used to assert via a weaker
+	// not-equal-to-unsigned guard.
+	assert.Equal(t, expectedSignedHash(t, sdk, unsigned, sigs, pubKey), hash)
 }
 
 func TestTHORChainIndexer_HashesMsgWithdrawDelegatorReward(t *testing.T) {
-	sdk := cosmossdk.NewSDK(nil)
-	rtypes.RegisterInterfaces(sdk.InterfaceRegistry())
-	sdk.RefreshCodec()
-
+	sdk := thorChainTestSDK()
 	indexer := NewTHORChainIndexer(sdk)
+	_, pubKey := testKeypair(t)
+	priv, _ := testKeypair(t)
+	sigs := map[string]tss.KeysignResponse{"signer-0": testSig(t, priv)}
 
 	msg := &distributiontypes.MsgWithdrawDelegatorReward{
 		DelegatorAddress: testDelegator,
@@ -177,28 +288,28 @@ func TestTHORChainIndexer_HashesMsgWithdrawDelegatorReward(t *testing.T) {
 	}
 	unsigned := buildUnsignedCosmosTx(t, msg)
 
-	pubKey := make([]byte, 33)
-	pubKey[0] = 0x02
-	sigs := map[string]tss.KeysignResponse{"signer-0": fakeSig()}
-
 	hash, err := indexer.ComputeTxHash(unsigned, sigs, pubKey)
 	require.NoError(t, err, "indexer must accept MsgWithdrawDelegatorReward after recipes Phase 1.5")
 	assert.Len(t, hash, 64)
 
-	// Sanity — the hash is the SHA256 hex of *something*; we just confirm shape.
 	_, err = hex.DecodeString(hash)
 	require.NoError(t, err, "indexer hash must be valid hex")
+
+	assert.Equal(t, expectedSignedHash(t, sdk, unsigned, sigs, pubKey), hash)
 }
 
-// TestTHORChainIndexer_HashIsSignedShape is a guard against accidentally
-// returning the unsigned tx hash. The verifier's contract is that the hash is
-// of the signed bytes (SHA256(signed)), not the unsigned bytes.
-func TestTHORChainIndexer_HashIsSignedShape(t *testing.T) {
-	sdk := cosmossdk.NewSDK(nil)
-	rtypes.RegisterInterfaces(sdk.InterfaceRegistry())
-	sdk.RefreshCodec()
-
+// TestTHORChainIndexer_HashIsSignedTxSHA256 replaces the earlier
+// HashIsSignedShape test, which only asserted that the hash differed from
+// SHA256(unsigned) — a tripwire that fires on any byte-changing transform,
+// not specifically on returning-the-wrong-bytes regressions. The real
+// contract is: ComputeTxHash returns upper-hex SHA256 of the marshalled
+// signed-tx bytes. We assert that exact equality here.
+func TestTHORChainIndexer_HashIsSignedTxSHA256(t *testing.T) {
+	sdk := thorChainTestSDK()
 	indexer := NewTHORChainIndexer(sdk)
+	_, pubKey := testKeypair(t)
+	priv, _ := testKeypair(t)
+	sigs := map[string]tss.KeysignResponse{"signer-0": testSig(t, priv)}
 
 	msg := &stakingtypes.MsgBeginRedelegate{
 		DelegatorAddress:    testDelegator,
@@ -208,20 +319,185 @@ func TestTHORChainIndexer_HashIsSignedShape(t *testing.T) {
 	}
 	unsigned := buildUnsignedCosmosTx(t, msg)
 
-	pubKey := make([]byte, 33)
-	pubKey[0] = 0x02
-	sigs := map[string]tss.KeysignResponse{"signer-0": fakeSig()}
-
 	hash, err := indexer.ComputeTxHash(unsigned, sigs, pubKey)
 	require.NoError(t, err)
 
-	// Compute SHA256 of the unsigned bytes — that's NOT what the indexer should
-	// return. (Cosmos hashes the *signed* tx bytes.)
-	unsignedHash := sha256.Sum256(unsigned)
-	unsignedHashHex := hex.EncodeToString(unsignedHash[:])
-	assert.NotEqualf(t,
-		fmt.Sprintf("%X", unsignedHash[:]), hash,
-		"indexer must hash the signed tx bytes, not the unsigned (got SHA256(unsigned)=%s)",
-		unsignedHashHex,
-	)
+	expected := expectedSignedHash(t, sdk, unsigned, sigs, pubKey)
+	assert.Equal(t, expected, hash, "indexer must return SHA256(signedTx) in upper hex")
+
+	// Cross-check: SHA256(unsignedTx) must NOT equal the indexer's hash —
+	// this covers the original regression-tripwire concern (the indexer
+	// must not accidentally hash the unsigned bytes).
+	unsignedSum := sha256.Sum256(unsigned)
+	assert.NotEqual(t, strings.ToUpper(hex.EncodeToString(unsignedSum[:])), hash)
+}
+
+// TestMayaChainIndexerRegistersStakingDistributionInterfaces mirrors the
+// THORChain wiring asserted above for the Maya indexer. chains_list.go wires
+// Maya with the same NewSDK + rtypes.RegisterInterfaces call THORChain uses,
+// so the new staking/distribution registrations should also be reachable
+// through MayaChainIndexer's SDK. Without this guard, a future divergence
+// between the two indexers' wiring (e.g. a Maya-specific SDK constructor that
+// skips RefreshCodec) would silently regress redelegate/withdraw_rewards
+// support on Maya only.
+func TestMayaChainIndexerRegistersStakingDistributionInterfaces(t *testing.T) {
+	sdk := mayaChainTestSDK()
+	indexer := NewMayaChainIndexer(sdk)
+	_, pubKey := testKeypair(t)
+	priv, _ := testKeypair(t)
+	sigs := map[string]tss.KeysignResponse{"signer-0": testSig(t, priv)}
+
+	t.Run("MsgBeginRedelegate hashes through Maya indexer", func(t *testing.T) {
+		msg := &stakingtypes.MsgBeginRedelegate{
+			DelegatorAddress:    testDelegator,
+			ValidatorSrcAddress: testValidatorSrc,
+			ValidatorDstAddress: testValidatorDst,
+			Amount:              cosmostypes.NewCoin("ucacao", math.NewInt(500_000)),
+		}
+		unsigned := buildUnsignedCosmosTx(t, msg)
+		hash, err := indexer.ComputeTxHash(unsigned, sigs, pubKey)
+		require.NoError(t, err)
+		assert.Equal(t, expectedSignedHash(t, sdk, unsigned, sigs, pubKey), hash)
+	})
+
+	t.Run("MsgWithdrawDelegatorReward hashes through Maya indexer", func(t *testing.T) {
+		msg := &distributiontypes.MsgWithdrawDelegatorReward{
+			DelegatorAddress: testDelegator,
+			ValidatorAddress: testValidator,
+		}
+		unsigned := buildUnsignedCosmosTx(t, msg)
+		hash, err := indexer.ComputeTxHash(unsigned, sigs, pubKey)
+		require.NoError(t, err)
+		assert.Equal(t, expectedSignedHash(t, sdk, unsigned, sigs, pubKey), hash)
+	})
+
+	t.Run("registry decodes both msg types", func(t *testing.T) {
+		ir := sdk.InterfaceRegistry()
+
+		redelegate := &stakingtypes.MsgBeginRedelegate{
+			DelegatorAddress:    testDelegator,
+			ValidatorSrcAddress: testValidatorSrc,
+			ValidatorDstAddress: testValidatorDst,
+			Amount:              cosmostypes.NewCoin("ucacao", math.NewInt(1)),
+		}
+		anyR, err := codectypes.NewAnyWithValue(redelegate)
+		require.NoError(t, err)
+		anyR = roundTripAny(t, anyR)
+		var decodedR cosmostypes.Msg
+		require.NoError(t, ir.UnpackAny(anyR, &decodedR))
+		_, ok := decodedR.(*stakingtypes.MsgBeginRedelegate)
+		assert.True(t, ok)
+
+		withdraw := &distributiontypes.MsgWithdrawDelegatorReward{
+			DelegatorAddress: testDelegator,
+			ValidatorAddress: testValidator,
+		}
+		anyW, err := codectypes.NewAnyWithValue(withdraw)
+		require.NoError(t, err)
+		anyW = roundTripAny(t, anyW)
+		var decodedW cosmostypes.Msg
+		require.NoError(t, ir.UnpackAny(anyW, &decodedW))
+		_, ok = decodedW.(*distributiontypes.MsgWithdrawDelegatorReward)
+		assert.True(t, ok)
+	})
+}
+
+// TestTHORChainIndexerDecodesMultiMsgWithStakingMsg covers a tx body that
+// mixes a bank.MsgSend with a staking.MsgBeginRedelegate. Real cosmos txs
+// often bundle messages — e.g. a wallet that auto-claims rewards before
+// delegating — and the indexer's hash path must handle the multi-msg shape
+// the same way it handles single-msg.
+func TestTHORChainIndexerDecodesMultiMsgWithStakingMsg(t *testing.T) {
+	sdk := thorChainTestSDK()
+	indexer := NewTHORChainIndexer(sdk)
+	_, pubKey := testKeypair(t)
+	priv, _ := testKeypair(t)
+	sigs := map[string]tss.KeysignResponse{"signer-0": testSig(t, priv)}
+
+	send := &banktypes.MsgSend{
+		FromAddress: testDelegator,
+		ToAddress:   testRecipient,
+		Amount:      cosmostypes.NewCoins(cosmostypes.NewCoin("uatom", math.NewInt(100_000))),
+	}
+	redelegate := &stakingtypes.MsgBeginRedelegate{
+		DelegatorAddress:    testDelegator,
+		ValidatorSrcAddress: testValidatorSrc,
+		ValidatorDstAddress: testValidatorDst,
+		Amount:              cosmostypes.NewCoin("uatom", math.NewInt(1_000_000)),
+	}
+
+	unsigned := buildUnsignedCosmosTx(t, send, redelegate)
+
+	hash, err := indexer.ComputeTxHash(unsigned, sigs, pubKey)
+	require.NoError(t, err, "indexer must hash multi-msg bodies (bank.MsgSend + staking.MsgBeginRedelegate)")
+	assert.Len(t, hash, 64)
+	assert.Equal(t, expectedSignedHash(t, sdk, unsigned, sigs, pubKey), hash)
+
+	// Also confirm the registry can decode both messages back from the
+	// envelope — this is the consumer's path when inspecting bundled txs.
+	var unsignedTx tx.Tx
+	require.NoError(t, unsignedTx.Unmarshal(unsigned))
+	require.Len(t, unsignedTx.Body.Messages, 2)
+
+	ir := sdk.InterfaceRegistry()
+	var m0, m1 cosmostypes.Msg
+	require.NoError(t, ir.UnpackAny(unsignedTx.Body.Messages[0], &m0))
+	require.NoError(t, ir.UnpackAny(unsignedTx.Body.Messages[1], &m1))
+	_, ok0 := m0.(*banktypes.MsgSend)
+	_, ok1 := m1.(*stakingtypes.MsgBeginRedelegate)
+	assert.True(t, ok0, "first message must decode as bank.MsgSend")
+	assert.True(t, ok1, "second message must decode as staking.MsgBeginRedelegate")
+}
+
+// TestTHORChainIndexerDecodesCrossEcosystemMsgs is the canary gomes asked
+// for: a tx body that mixes THORChain's MsgDeposit (registered via
+// rtypes.RegisterInterfaces) with a generic cosmos staking MsgBeginRedelegate
+// (registered by NewSDK). Both must round-trip through the same THORChain
+// SDK without one ecosystem's registration shadowing the other's.
+//
+// This isn't a tx shape that thornode would broadcast in practice, but it's
+// the strongest assertion that the two registrations coexist in the same
+// codec: if a future recipes change accidentally drops or replaces one set
+// of registrations during NewSDK setup, this test catches it.
+func TestTHORChainIndexerDecodesCrossEcosystemMsgs(t *testing.T) {
+	sdk := thorChainTestSDK()
+	indexer := NewTHORChainIndexer(sdk)
+	_, pubKey := testKeypair(t)
+	priv, _ := testKeypair(t)
+	sigs := map[string]tss.KeysignResponse{"signer-0": testSig(t, priv)}
+
+	// THORChain MsgDeposit — fields per recipes/types/thorchain.pb.go.
+	deposit := &rtypes.MsgDeposit{
+		Memo:   "=:ETH.ETH:0xdeadbeef",
+		Signer: []byte("thor1signerxxxxxxxxxxxxxxxxxxxxxxxx"),
+	}
+
+	// Generic cosmos staking MsgBeginRedelegate.
+	redelegate := &stakingtypes.MsgBeginRedelegate{
+		DelegatorAddress:    testDelegator,
+		ValidatorSrcAddress: testValidatorSrc,
+		ValidatorDstAddress: testValidatorDst,
+		Amount:              cosmostypes.NewCoin("uatom", math.NewInt(1_000_000)),
+	}
+
+	unsigned := buildUnsignedCosmosTx(t, deposit, redelegate)
+
+	hash, err := indexer.ComputeTxHash(unsigned, sigs, pubKey)
+	require.NoError(t, err, "indexer must hash bodies mixing thor MsgDeposit + cosmos staking msg")
+	assert.Len(t, hash, 64)
+	assert.Equal(t, expectedSignedHash(t, sdk, unsigned, sigs, pubKey), hash)
+
+	// Both messages decode through the same registry.
+	var unsignedTx tx.Tx
+	require.NoError(t, unsignedTx.Unmarshal(unsigned))
+	require.Len(t, unsignedTx.Body.Messages, 2)
+
+	ir := sdk.InterfaceRegistry()
+	var m0, m1 cosmostypes.Msg
+	require.NoError(t, ir.UnpackAny(unsignedTx.Body.Messages[0], &m0))
+	require.NoError(t, ir.UnpackAny(unsignedTx.Body.Messages[1], &m1))
+	_, ok0 := m0.(*rtypes.MsgDeposit)
+	_, ok1 := m1.(*stakingtypes.MsgBeginRedelegate)
+	assert.True(t, ok0, "first message must decode as thorchain MsgDeposit (rtypes registration intact)")
+	assert.True(t, ok1, "second message must decode as staking MsgBeginRedelegate (NewSDK registration intact)")
 }

--- a/plugin/tx_indexer/pkg/chain/cosmos_msg_types_test.go
+++ b/plugin/tx_indexer/pkg/chain/cosmos_msg_types_test.go
@@ -19,19 +19,26 @@ import (
 	rtypes "github.com/vultisig/recipes/types"
 )
 
-// These tests guard the verifier's hashing path against recipes regressions for
-// the two staking/distribution messages that mcp-ts PR #72 + the
-// recipes/verifier Phase 1.5 schemas introduced. They sign a fixture
-// MsgBeginRedelegate and MsgWithdrawDelegatorReward via the recipes Cosmos SDK
-// and assert:
-//   1. the SDK's interface registry knows the message types (otherwise Sign
-//      panics inside protobuf-Any unpacking),
-//   2. the resulting hash is deterministic and matches the SHA256 the indexer
-//      promises to upstream callers.
+// These tests guard two distinct invariants the verifier needs after recipes
+// Phase 1.5 lands the staking/distribution schemas:
 //
-// If a future recipes bump removes stakingtypes.RegisterInterfaces /
-// distributiontypes.RegisterInterfaces from sdk/cosmos/sdk.go, these tests
-// fail loudly here rather than at runtime when a real redelegate broadcasts.
+//  1. The recipes Cosmos SDK's InterfaceRegistry knows the new message types.
+//     This is what consumers of `sdk.InterfaceRegistry()` (including downstream
+//     decoders that DO need to UnpackAny the body messages — e.g. anything
+//     that inspects the redelegate amount or validator addresses post-sign)
+//     rely on. We assert this directly via `UnpackAny` in
+//     TestRecipesSDKRegistersStakingDistributionInterfaces.
+//
+//  2. The end-to-end indexer hash path (`Sign + ComputeTxHash`) accepts the
+//     new tx shapes and produces a stable SHA256 of the signed bytes. Note
+//     that Sign() itself only round-trips the outer tx.Tx envelope — it does
+//     not UnpackAny the body messages — so the hash tests don't *require*
+//     the new interface registrations to pass. They guard the broader
+//     contract: an indexer fed an unsigned redelegate/withdraw_rewards tx
+//     should not error, and the hash is shaped like all other cosmos hashes.
+//
+// If a future recipes bump regresses either invariant, the failure surfaces
+// here rather than at runtime when a real redelegate broadcasts.
 
 const (
 	testDelegator    = "cosmos1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
@@ -78,6 +85,51 @@ func buildUnsignedCosmosTx(t *testing.T, msg cosmostypes.Msg) []byte {
 	bz, err := unsigned.Marshal()
 	require.NoError(t, err)
 	return bz
+}
+
+// TestRecipesSDKRegistersStakingDistributionInterfaces asserts the actual
+// behavior change recipes Phase 1.5 introduces: a freshly-built recipes
+// Cosmos SDK can decode a /cosmos.staking.v1beta1.MsgBeginRedelegate and a
+// /cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward off the wire. This
+// is the load-bearing assertion for any verifier consumer that goes beyond
+// envelope round-tripping (e.g. policy evaluation, parameter extraction).
+func TestRecipesSDKRegistersStakingDistributionInterfaces(t *testing.T) {
+	sdk := cosmossdk.NewSDK(nil)
+	ir := sdk.InterfaceRegistry()
+
+	t.Run("MsgBeginRedelegate decodes via SDK registry", func(t *testing.T) {
+		original := &stakingtypes.MsgBeginRedelegate{
+			DelegatorAddress:    testDelegator,
+			ValidatorSrcAddress: testValidatorSrc,
+			ValidatorDstAddress: testValidatorDst,
+			Amount:              cosmostypes.NewCoin("uatom", math.NewInt(1_000_000)),
+		}
+		any, err := codectypes.NewAnyWithValue(original)
+		require.NoError(t, err)
+		assert.Equal(t, "/cosmos.staking.v1beta1.MsgBeginRedelegate", any.TypeUrl)
+
+		var decoded cosmostypes.Msg
+		err = ir.UnpackAny(any, &decoded)
+		require.NoError(t, err, "recipes SDK must register stakingtypes.RegisterInterfaces")
+		_, ok := decoded.(*stakingtypes.MsgBeginRedelegate)
+		assert.True(t, ok)
+	})
+
+	t.Run("MsgWithdrawDelegatorReward decodes via SDK registry", func(t *testing.T) {
+		original := &distributiontypes.MsgWithdrawDelegatorReward{
+			DelegatorAddress: testDelegator,
+			ValidatorAddress: testValidator,
+		}
+		any, err := codectypes.NewAnyWithValue(original)
+		require.NoError(t, err)
+		assert.Equal(t, "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward", any.TypeUrl)
+
+		var decoded cosmostypes.Msg
+		err = ir.UnpackAny(any, &decoded)
+		require.NoError(t, err, "recipes SDK must register distributiontypes.RegisterInterfaces")
+		_, ok := decoded.(*distributiontypes.MsgWithdrawDelegatorReward)
+		assert.True(t, ok)
+	})
 }
 
 func TestTHORChainIndexer_HashesMsgBeginRedelegate(t *testing.T) {

--- a/plugin/tx_indexer/pkg/chain/cosmos_msg_types_test.go
+++ b/plugin/tx_indexer/pkg/chain/cosmos_msg_types_test.go
@@ -1,0 +1,175 @@
+package chain
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"cosmossdk.io/math"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	cosmostypes "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/tx"
+	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vultisig/mobile-tss-lib/tss"
+	cosmossdk "github.com/vultisig/recipes/sdk/cosmos"
+	rtypes "github.com/vultisig/recipes/types"
+)
+
+// These tests guard the verifier's hashing path against recipes regressions for
+// the two staking/distribution messages that mcp-ts PR #72 + the
+// recipes/verifier Phase 1.5 schemas introduced. They sign a fixture
+// MsgBeginRedelegate and MsgWithdrawDelegatorReward via the recipes Cosmos SDK
+// and assert:
+//   1. the SDK's interface registry knows the message types (otherwise Sign
+//      panics inside protobuf-Any unpacking),
+//   2. the resulting hash is deterministic and matches the SHA256 the indexer
+//      promises to upstream callers.
+//
+// If a future recipes bump removes stakingtypes.RegisterInterfaces /
+// distributiontypes.RegisterInterfaces from sdk/cosmos/sdk.go, these tests
+// fail loudly here rather than at runtime when a real redelegate broadcasts.
+
+const (
+	testDelegator    = "cosmos1delegatorxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+	testValidatorSrc = "cosmosvaloper1srcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+	testValidatorDst = "cosmosvaloper1dstxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+	testValidator    = "cosmosvaloper1abcxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+)
+
+// fakeSig returns a 64-byte deterministic R || S split that the recipes SDK
+// will accept (low-S normalization happens inside Sign()).
+func fakeSig() tss.KeysignResponse {
+	return tss.KeysignResponse{
+		R: hex.EncodeToString(make([]byte, 32)),
+		S: hex.EncodeToString(append([]byte{0x01}, make([]byte, 31)...)),
+	}
+}
+
+// buildUnsignedCosmosTx wraps any sdk.Msg into a minimal tx.Tx with no
+// SignerInfos (Sign() injects the signer info from the provided pubkey).
+// This mirrors the shape that vultisig-app's cosmosTx.ts emits before
+// keysign — the unsigned bytes the verifier indexer receives.
+func buildUnsignedCosmosTx(t *testing.T, msg cosmostypes.Msg) []byte {
+	t.Helper()
+
+	any, err := codectypes.NewAnyWithValue(msg)
+	require.NoError(t, err)
+
+	body := &tx.TxBody{
+		Messages: []*codectypes.Any{any},
+	}
+
+	authInfo := &tx.AuthInfo{
+		Fee: &tx.Fee{
+			Amount:   cosmostypes.NewCoins(cosmostypes.NewCoin("uatom", math.NewInt(7_500))),
+			GasLimit: 200_000,
+		},
+	}
+
+	unsigned := &tx.Tx{
+		Body:     body,
+		AuthInfo: authInfo,
+	}
+
+	bz, err := unsigned.Marshal()
+	require.NoError(t, err)
+	return bz
+}
+
+func TestTHORChainIndexer_HashesMsgBeginRedelegate(t *testing.T) {
+	// Use the same wiring as chains_list.go: NewSDK with thor/maya types
+	// registered. With the recipes Phase 1.5 patch, NewSDK auto-registers
+	// staking + distribution interfaces too, so MsgBeginRedelegate decodes.
+	sdk := cosmossdk.NewSDK(nil)
+	rtypes.RegisterInterfaces(sdk.InterfaceRegistry())
+	sdk.RefreshCodec()
+
+	indexer := NewTHORChainIndexer(sdk)
+
+	msg := &stakingtypes.MsgBeginRedelegate{
+		DelegatorAddress:    testDelegator,
+		ValidatorSrcAddress: testValidatorSrc,
+		ValidatorDstAddress: testValidatorDst,
+		Amount:              cosmostypes.NewCoin("uatom", math.NewInt(1_000_000)),
+	}
+	unsigned := buildUnsignedCosmosTx(t, msg)
+
+	pubKey := make([]byte, 33)
+	pubKey[0] = 0x02
+	sigs := map[string]tss.KeysignResponse{"signer-0": fakeSig()}
+
+	hash, err := indexer.ComputeTxHash(unsigned, sigs, pubKey)
+	require.NoError(t, err, "indexer must accept MsgBeginRedelegate after recipes Phase 1.5")
+	assert.Len(t, hash, 64, "cosmos tx hash is uppercase hex SHA256 of signed bytes")
+
+	// Determinism: two calls with the same inputs produce the same hash.
+	hash2, err := indexer.ComputeTxHash(unsigned, sigs, pubKey)
+	require.NoError(t, err)
+	assert.Equal(t, hash, hash2)
+}
+
+func TestTHORChainIndexer_HashesMsgWithdrawDelegatorReward(t *testing.T) {
+	sdk := cosmossdk.NewSDK(nil)
+	rtypes.RegisterInterfaces(sdk.InterfaceRegistry())
+	sdk.RefreshCodec()
+
+	indexer := NewTHORChainIndexer(sdk)
+
+	msg := &distributiontypes.MsgWithdrawDelegatorReward{
+		DelegatorAddress: testDelegator,
+		ValidatorAddress: testValidator,
+	}
+	unsigned := buildUnsignedCosmosTx(t, msg)
+
+	pubKey := make([]byte, 33)
+	pubKey[0] = 0x02
+	sigs := map[string]tss.KeysignResponse{"signer-0": fakeSig()}
+
+	hash, err := indexer.ComputeTxHash(unsigned, sigs, pubKey)
+	require.NoError(t, err, "indexer must accept MsgWithdrawDelegatorReward after recipes Phase 1.5")
+	assert.Len(t, hash, 64)
+
+	// Sanity — the hash is the SHA256 hex of *something*; we just confirm shape.
+	_, err = hex.DecodeString(hash)
+	require.NoError(t, err, "indexer hash must be valid hex")
+}
+
+// TestTHORChainIndexer_HashIsSignedShape is a guard against accidentally
+// returning the unsigned tx hash. The verifier's contract is that the hash is
+// of the signed bytes (SHA256(signed)), not the unsigned bytes.
+func TestTHORChainIndexer_HashIsSignedShape(t *testing.T) {
+	sdk := cosmossdk.NewSDK(nil)
+	rtypes.RegisterInterfaces(sdk.InterfaceRegistry())
+	sdk.RefreshCodec()
+
+	indexer := NewTHORChainIndexer(sdk)
+
+	msg := &stakingtypes.MsgBeginRedelegate{
+		DelegatorAddress:    testDelegator,
+		ValidatorSrcAddress: testValidatorSrc,
+		ValidatorDstAddress: testValidatorDst,
+		Amount:              cosmostypes.NewCoin("uatom", math.NewInt(2_000_000)),
+	}
+	unsigned := buildUnsignedCosmosTx(t, msg)
+
+	pubKey := make([]byte, 33)
+	pubKey[0] = 0x02
+	sigs := map[string]tss.KeysignResponse{"signer-0": fakeSig()}
+
+	hash, err := indexer.ComputeTxHash(unsigned, sigs, pubKey)
+	require.NoError(t, err)
+
+	// Compute SHA256 of the unsigned bytes — that's NOT what the indexer should
+	// return. (Cosmos hashes the *signed* tx bytes.)
+	unsignedHash := sha256.Sum256(unsigned)
+	unsignedHashHex := hex.EncodeToString(unsignedHash[:])
+	assert.NotEqualf(t,
+		fmt.Sprintf("%X", unsignedHash[:]), hash,
+		"indexer must hash the signed tx bytes, not the unsigned (got SHA256(unsigned)=%s)",
+		unsignedHashHex,
+	)
+}


### PR DESCRIPTION
## Summary

Bump `vultisig/recipes` to the Phase 1.5 cut that registers the staking + distribution interfaces in the Cosmos SDK and adds policy-engine unpack/extract for `MsgBeginRedelegate` and `MsgWithdrawDelegatorReward`. Add tx-indexer tests that pin the new behavior at the verifier boundary.

Without this bump, even after mcp-ts PR #72 advertises the staking write tools, the verifier's Cosmos SDK codec has no concrete type for the incoming `Any.TypeUrl` on these messages — hashing fails and the tx is dropped on the indexer floor. With the bump, the existing THORChain / MayaChain indexers (which delegate to the recipes Cosmos SDK) handle generic Cosmos staking/distribution txs end-to-end with no per-chain wiring.

These two msgs are generic Cosmos SDK and unlock the same code path for Cosmos Hub, Osmosis, Kujira, Akash, Dydx, Noble alongside Terra (phoenix-1) and Terra Classic (columbus-5).

## Verifier-side changes

- `go.mod` / `go.sum` — bump `github.com/vultisig/recipes` from `577976dfb292` (verifier main) to `475ad1fe90db` (recipes#589 HEAD). `cosmossdk.io/math` and `github.com/cosmos/cosmos-sdk` move from indirect to direct, which is mechanical: the new test file imports them and `go mod tidy` promotes accordingly. No new transitive deps beyond what recipes already pulled in.
- `plugin/tx_indexer/pkg/chain/cosmos_msg_types_test.go` (new) — six test groups:
  - **`TestRecipesSDKRegistersStakingDistributionInterfaces`** — `UnpackAny` assertion forced through the registry path by marshal+unmarshal of the `Any` first. Without the round-trip, `NewAnyWithValue` caches the source pointer and `UnpackAny` short-circuits on `cachedValue` — meaning the assertion would pass even with no registration. Verified locally by patching out `stakingtypes.RegisterInterfaces` / `distributiontypes.RegisterInterfaces` in `recipes/sdk/cosmos/sdk.go`: the test now fails with `no concrete type registered for type URL /cosmos.staking.v1beta1.MsgBeginRedelegate`.
  - **`TestTHORChainIndexer_HashesMsgBeginRedelegate` / `_HashesMsgWithdrawDelegatorReward`** — end-to-end `Sign + ComputeTxHash` on representative redelegate / withdraw_rewards fixtures. Asserts byte-exact equality with `SHA256(signedTx)` plus determinism.
  - **`TestTHORChainIndexer_HashIsSignedTxSHA256`** — replaces the earlier `_HashIsSignedShape` test (which only asserted `hash != SHA256(unsigned)`, a tripwire that fires on any byte-changing transform). New assertion is byte-exact equality with the upper-hex SHA256 of the marshalled signed-tx bytes.
  - **`TestMayaChainIndexerRegistersStakingDistributionInterfaces`** — same registry + hash assertions for `NewMayaChainIndexer`. `chains_list.go` wires Maya through `cosmossdk.NewSDK(nil)` exactly as it wires THORChain, but a future divergence (e.g. a Maya-specific SDK constructor that skips `RefreshCodec`) would silently regress redelegate / withdraw_rewards on Maya only — this test catches that.
  - **`TestTHORChainIndexerDecodesMultiMsgWithStakingMsg`** — `bank.MsgSend + staking.MsgBeginRedelegate` in one tx body. Real cosmos txs often bundle messages (auto-claim before delegate), and the indexer's hash path must handle the multi-msg shape.
  - **`TestTHORChainIndexerDecodesCrossEcosystemMsgs`** — canary: thor `MsgDeposit` (registered via `rtypes.RegisterInterfaces`) + cosmos staking `MsgBeginRedelegate` (registered by `NewSDK`) in the same body, both round-tripping through the same THORChain SDK. Catches future registration shadowing between the two ecosystems.

Real-shape fixtures: real cosmoshub-4 bech32 addresses (delegator + two known mainnet validators), real on-curve secp256k1 keypair via `GenPrivKeyFromSecret`, real signature via `priv.Sign()`. Replaces the earlier off-curve `pubKey[0] = 0x02` placeholder and zero-R `fakeSig`.

## Pattern fidelity

The verifier-side change is intentionally minimal — the recipes change is the load-bearing one. Verifier's `chains_list.go` calls `cosmossdk.NewSDK(nil)` for THORChain + Maya, and the recipes update auto-registers staking + distribution interfaces in `NewSDK`. No per-chain wiring changes are needed.

## What this bumps beyond cosmos staking

The recipes pin moves from `577976dfb292` (verifier main) to `475ad1fe90db` (recipes#589 HEAD) — 59 commits, +4232 / −172 lines across 44 files. The cosmos staking schemas are 632 lines of that. The remaining ~3600 lines are unrelated SDK growth that landed on recipes/main between Jan 29 and Apr 30. Disclosed for review:

- AAVE v3 SDK — `sdk/evm/aavev3/{abi,addresses,builder,client}.go` + `chain/evm/abi/aavev3_*.json` + `sdk/evm/codegen/aavev3_*` (~700 LOC, +2 ABI files)
- Polymarket CTF + CTF Exchange — `sdk/evm/codegen/polymarket_ctf{,_exchange}/*.go` (~230 LOC)
- Cetus swap SDK — `sdk/swap/cetus.go` (190 LOC, new)
- Relay swap SDK — `sdk/swap/relay.go` (510 LOC, new) + service/router rewiring
- THORChain router codegen — `sdk/evm/codegen/thorchain_router/thorchain_router.go` (+95, −15)
- MayaChain router codegen — `sdk/evm/codegen/mayachain_router/mayachain_router.go` (+496, new file)
- Uniswap v2 router codegen rewrite — `sdk/evm/codegen/uniswapv2_router/uniswapv2_router.go` (+285, −51)
- ERC20 codegen rewrite — `sdk/evm/codegen/erc20/erc20.go` (+110, −20)
- LiFi + swap-service refactors — `sdk/swap/{lifi,service,router,thorchain,mayachain,types}.go`
- THORChain native receive resolver — `resolver/thorchain_common.go` etc (`always-available for native THORChain/MayaChain receives`)
- `RESOURCES.md` (+284) — recipes-side documentation, no runtime effect

None of these touch cosmos staking, the tx_indexer, or any verifier-direct surface. The `chains_list.go` paths that the verifier uses (`cosmossdk.NewSDK`, `btc.NewSDK`, `solana.NewSDK`, `xrpl.NewSDK`, `tron.NewSDK`) are exercised by the receipts below; the EVM swap SDK growth above is consumed only via mcp-ts, not directly by verifier.

## Paired PR

- vultisig/recipes#589 — adds the schemas, codec registration, and policy-engine unpack/extract paths.

## Codex 5.4 second-opinion

Run pre-promotion. Findings:
- Type URLs match cosmos-sdk v0.50.x upstream
- Bech32 prefix non-validation in the generic engine is correct (consistent with `MsgSend`, chain-keeper validates at execution time)
- `IsNil + IsPositive` covers the structural amount cases
- Cross-registering generic cosmos staking types into the THORChain/Maya SDK instance is harmless (disjoint type URLs)

Subsequent CR feedback on recipes#589 (empty-address validation on redelegate / withdraw_rewards) addressed in commits `1d5f4ac9`, `e9919915`, `475ad1fe`. This PR's pin update picks all three up.

CR feedback on verifier#581 — registry test cached-pointer short-circuit, off-curve pubkey + zero-R signature placeholders, weak hash-shape assertion, missing Maya / multi-msg / cross-ecosystem coverage — addressed in this commit.

## Refs

- `vultisig-ops/.spikes/terra-readiness-checkpoint-2026-04-30.md` § B.5 — gap evidence
- `vultisig-ops/.spikes/terra-product-plan.md` — Phase 1.5 description

## ci receipts

`go test ./plugin/tx_indexer/pkg/chain/... -count=1 -v`:

```
=== RUN   TestRecipesSDKRegistersStakingDistributionInterfaces
=== RUN   TestRecipesSDKRegistersStakingDistributionInterfaces/MsgBeginRedelegate_decodes_via_SDK_registry
=== RUN   TestRecipesSDKRegistersStakingDistributionInterfaces/MsgWithdrawDelegatorReward_decodes_via_SDK_registry
--- PASS: TestRecipesSDKRegistersStakingDistributionInterfaces (0.00s)
    --- PASS: TestRecipesSDKRegistersStakingDistributionInterfaces/MsgBeginRedelegate_decodes_via_SDK_registry (0.00s)
    --- PASS: TestRecipesSDKRegistersStakingDistributionInterfaces/MsgWithdrawDelegatorReward_decodes_via_SDK_registry (0.00s)
=== RUN   TestTHORChainIndexer_HashesMsgBeginRedelegate
--- PASS: TestTHORChainIndexer_HashesMsgBeginRedelegate (0.00s)
=== RUN   TestTHORChainIndexer_HashesMsgWithdrawDelegatorReward
--- PASS: TestTHORChainIndexer_HashesMsgWithdrawDelegatorReward (0.00s)
=== RUN   TestTHORChainIndexer_HashIsSignedTxSHA256
--- PASS: TestTHORChainIndexer_HashIsSignedTxSHA256 (0.00s)
=== RUN   TestMayaChainIndexerRegistersStakingDistributionInterfaces
=== RUN   TestMayaChainIndexerRegistersStakingDistributionInterfaces/MsgBeginRedelegate_hashes_through_Maya_indexer
=== RUN   TestMayaChainIndexerRegistersStakingDistributionInterfaces/MsgWithdrawDelegatorReward_hashes_through_Maya_indexer
=== RUN   TestMayaChainIndexerRegistersStakingDistributionInterfaces/registry_decodes_both_msg_types
--- PASS: TestMayaChainIndexerRegistersStakingDistributionInterfaces (0.00s)
    --- PASS: TestMayaChainIndexerRegistersStakingDistributionInterfaces/MsgBeginRedelegate_hashes_through_Maya_indexer (0.00s)
    --- PASS: TestMayaChainIndexerRegistersStakingDistributionInterfaces/MsgWithdrawDelegatorReward_hashes_through_Maya_indexer (0.00s)
    --- PASS: TestMayaChainIndexerRegistersStakingDistributionInterfaces/registry_decodes_both_msg_types (0.00s)
=== RUN   TestTHORChainIndexerDecodesMultiMsgWithStakingMsg
--- PASS: TestTHORChainIndexerDecodesMultiMsgWithStakingMsg (0.00s)
=== RUN   TestTHORChainIndexerDecodesCrossEcosystemMsgs
--- PASS: TestTHORChainIndexerDecodesCrossEcosystemMsgs (0.00s)
=== RUN   TestTHORChainIndexer_NilSDK
--- PASS: TestTHORChainIndexer_NilSDK (0.00s)
PASS
ok  	github.com/vultisig/verifier/plugin/tx_indexer/pkg/chain	0.517s
```

`go test ./plugin/tx_indexer/... -count=1`:

```
ok  	github.com/vultisig/verifier/plugin/tx_indexer	1.305s
ok  	github.com/vultisig/verifier/plugin/tx_indexer/pkg/chain	0.443s
?   	github.com/vultisig/verifier/plugin/tx_indexer/pkg/config	[no test files]
?   	github.com/vultisig/verifier/plugin/tx_indexer/pkg/conv	[no test files]
?   	github.com/vultisig/verifier/plugin/tx_indexer/pkg/graceful	[no test files]
ok  	github.com/vultisig/verifier/plugin/tx_indexer/pkg/rpc	0.724s
?   	github.com/vultisig/verifier/plugin/tx_indexer/pkg/storage	[no test files]
```

EVM indexer (`plugin/tx_indexer/pkg/rpc/evm_errors_test.go` covers the EVM revert decoding path; the EVM indexer itself is at `plugin/tx_indexer/pkg/chain/evm.go` with no dedicated test file). Note: this repo organizes indexers under `plugin/tx_indexer/pkg/chain/`, not `internal/indexer/{evm,thor}/`. The EVM RPC error tests above (last block) cover the EVM-specific paths the bump could touch.

Full repo:

```
ok  	github.com/vultisig/verifier/config	0.302s
ok  	github.com/vultisig/verifier/internal/portal	1.637s
ok  	github.com/vultisig/verifier/internal/service	0.558s
ok  	github.com/vultisig/verifier/internal/sigutil	1.854s
ok  	github.com/vultisig/verifier/internal/storage/postgres	1.067s
ok  	github.com/vultisig/verifier/internal/util	1.558s
ok  	github.com/vultisig/verifier/plugin/libhttp	1.827s
ok  	github.com/vultisig/verifier/plugin/tx_indexer	1.460s
ok  	github.com/vultisig/verifier/plugin/tx_indexer/pkg/chain	0.874s
ok  	github.com/vultisig/verifier/plugin/tx_indexer/pkg/rpc	1.018s
ok  	github.com/vultisig/verifier/vault	0.722s
```

Robot-generated.



## qa receipts

End-to-end runtime probe pulled real on-chain raw protobuf tx bytes from production LCDs (phoenix-1, thornode, mayanode) and fed them through the recipes Cosmos SDK's `InterfaceRegistry` + the verifier's `THORChainIndexer` / `MayaChainIndexer` factory output. This is the runtime evidence the existing CI tests can't provide — those round-trip synthetic fixtures, this exercises the registry path with bytes that came off real production validators on real production chains.

Probe lives at `/tmp/verifier-indexer-probe/probe_test.go` (QA-only, never committed). It uses `replace github.com/vultisig/verifier => ../worktrees/verifier-pr581` to import the PR-branch indexer code unmodified.

### Fixtures (4 real on-chain txs, SHA256 of fixture file == claimed txid)

| chain | txid | type | size |
|---|---|---|---|
| phoenix-1 | `D2529B4A33D7879E8445996932EC360478DCB6196FB1B4628757D10E87D1CAC8` | `/cosmos.staking.v1beta1.MsgBeginRedelegate` (height 20799755, 304 LUNA redelegate) | 398 B |
| phoenix-1 | `D104A37D03D878189B2601370B139AF3E689DA4184140EC7FDA6A8073E8787E4` | 8x `/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward` (height 20801634, multi-validator reward claim) | 1464 B |
| thornode  | `040F3EEA0B85AF107320860237D42022304AC0A95DC108FA6AE6A06DBFF0CBFD` | `/types.MsgDeposit` (BTC→BSC.USDC swap, real memo + real signer) | 354 B |
| mayanode  | `35D4D77F7B2141C06F3C22816EFE81964715EC46EB33E23E77F947F646B3F309` | `/types.MsgDeposit` (BTC→ZEC swap, real memo + real signer) | 366 B |

`TestProbe_FixtureProvenance` asserts each fixture's SHA256 == claimed txid (Cosmos tx hash IS SHA256(rawTxBytes)), proving the fixtures are not locally fabricated.

### Probe results (10/10 pass)

`go test -count=1 -v ./...` from `/tmp/verifier-indexer-probe/`:

```
=== RUN   TestProbe_Phoenix1_MsgBeginRedelegate
    decoded delegator=terra1u7pzpfhn4sw8e27g56g6ucfyunwkmk48qd3czd src=terravaloper1hy8lzd38kp0t8662r2vnxsc4ezs3l74506jx02 dst=terravaloper1u53qwdgafryksqnzq3k7e5eyph7jlh8kgc3va4 amount=304000000uluna
    indexer hash (synthetic re-sign) = 11AFF109A813F1E5F265A7FB86BE40058CB77049850F25C805C5C75C33CEDEA9
--- PASS: TestProbe_Phoenix1_MsgBeginRedelegate (0.00s)
=== RUN   TestProbe_Phoenix1_MsgWithdrawDelegatorReward
    decoded all 8 MsgWithdrawDelegatorReward msgs from phoenix1 tx D104A3...87E4
    indexer hash (synthetic re-sign) = C5DF9EA2C0C11C0F4C8AA021D6324B031C401241714EA0C2EEBAAE045FAEF1E1
--- PASS: TestProbe_Phoenix1_MsgWithdrawDelegatorReward (0.00s)
=== RUN   TestProbe_THOR_MsgDeposit
    decoded thor MsgDeposit memo="=:BSC~USDC-0X8AC76A51CC950D9822D68B83FE1AD97B32CD580D:thor14mh37ua4vkyur0l5ra297a4la6tmf95mt96a55:19681801427/1/1" signer_len=20 coin_amount=254538 asset=BTC.BTC
    indexer hash (synthetic re-sign) = C970CEB8B6727E11554E38194505D3669D3EA9B69CF9D8448B5984AE563C109D
--- PASS: TestProbe_THOR_MsgDeposit (0.00s)
=== RUN   TestProbe_Maya_MsgDeposit
    decoded maya MsgDeposit memo="=:ZEC~ZEC:maya176820wmjp536wtsddxn4y52ghp3w23k747hard:32506078" coin_amount=146574 asset=BTC.BTC
    indexer hash (synthetic re-sign) = B6BD281F58F47F017FC20983CE811703ED8B314B25DB8ECAD92ABD473E3E6EBB
--- PASS: TestProbe_Maya_MsgDeposit (0.00s)
=== RUN   TestProbe_FixtureProvenance
    --- PASS: phoenix1_redelegate.bin SHA256=D2529B4A33D7879E8445996932EC360478DCB6196FB1B4628757D10E87D1CAC8
    --- PASS: phoenix1_withdraw.bin    SHA256=D104A37D03D878189B2601370B139AF3E689DA4184140EC7FDA6A8073E8787E4
    --- PASS: thornode_msgdeposit.bin  SHA256=040F3EEA0B85AF107320860237D42022304AC0A95DC108FA6AE6A06DBFF0CBFD
    --- PASS: maya_msgdeposit.bin      SHA256=35D4D77F7B2141C06F3C22816EFE81964715EC46EB33E23E77F947F646B3F309
=== RUN   TestProbe_AdversarialDecodeWithoutStakingOnly
    targeted negative control: failure cites typeUrl as expected: no concrete type registered for type URL /cosmos.staking.v1beta1.MsgBeginRedelegate against interface *interface { ProtoMessage(); Reset(); String() string }
--- PASS
=== RUN   TestProbe_AdversarialDecodeWithoutDistributionOnly
    targeted negative control (distribution): no concrete type registered for type URL /cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward against interface *interface { ProtoMessage(); Reset(); String() string }
--- PASS
=== RUN   TestProbe_ProductionFactoryPath
    production-factory THORChain hash redelegate: 11AFF109A813F1E5F265A7FB86BE40058CB77049850F25C805C5C75C33CEDEA9
    production-factory MayaChain hash redelegate: 11AFF109A813F1E5F265A7FB86BE40058CB77049850F25C805C5C75C33CEDEA9
    production-factory THORChain hash MsgDeposit: C970CEB8B6727E11554E38194505D3669D3EA9B69CF9D8448B5984AE563C109D
--- PASS
=== RUN   TestProbe_NewSDKBaselineMatchesHandWiring
    hand-wired probe SDK matches reconstructed NewSDK baseline
--- PASS
=== RUN   TestProbe_AdversarialDecodeWithoutNewRegistration
    bare-registry decode failed as expected
--- PASS
PASS
ok  	verifier-indexer-probe	0.454s
```

### What each probe proves

| probe | invariant under test | how it differs from CI tests |
|---|---|---|
| `TestProbe_Phoenix1_MsgBeginRedelegate` | recipes SDK registry decodes a REAL on-chain phoenix-1 redelegate, fields match LCD | CI tests round-trip synthetic msgs; this consumes real wire bytes |
| `TestProbe_Phoenix1_MsgWithdrawDelegatorReward` | registry decodes all 8 messages in a multi-msg withdraw_rewards body | catches "first-Any-only" registry bugs |
| `TestProbe_THOR_MsgDeposit` | rtypes.MsgDeposit still decodes after Phase 1.5 (regression) | uses real swap memo + signer bytes |
| `TestProbe_Maya_MsgDeposit` | maya MsgDeposit still decodes | proves Maya wiring matches THOR wiring |
| `TestProbe_FixtureProvenance` | fixture SHA256 == claimed txid for all 4 | proves fixtures are real on-chain bytes, not fabricated |
| `TestProbe_AdversarialDecodeWithoutStakingOnly` | registry-minus-staking-only fails decode citing exact typeUrl | targeted control: staking registration is the load-bearing delta (not "no registrations") |
| `TestProbe_AdversarialDecodeWithoutDistributionOnly` | registry-minus-distribution-only fails decode citing exact typeUrl | targeted control: distribution registration is independently load-bearing |
| `TestProbe_ProductionFactoryPath` | `tx_indexer.Chains()` factory output (production wiring) accepts the new bodies | catches future drift in `chains_list.go` (e.g. someone removing RefreshCodec) |
| `TestProbe_NewSDKBaselineMatchesHandWiring` | hand-wired probe SDK matches reconstructed NewSDK + rtypes baseline | documents why the probe's helpers are trustworthy |
| `TestProbe_AdversarialDecodeWithoutNewRegistration` | empty registry can't decode anything (broad sanity check) | weakest control, kept for completeness |

### Adversarial review (codex-cli gpt-5.4)

Codex was asked to argue against the probe. It raised 7 concerns; the probe was strengthened in response and the strengthened version addresses each:

| # | Concern (from codex) | Resolution |
|---|---|---|
| 1 | "Hash-path probes don't prove registry — `Sign()` doesn't `UnpackAny` body messages" | Concerns separated: registry is proved by `*DecodeWithout*` tests, not the hash-path tests |
| 2 | "`roundTripAny` may not actually clear cachedValue for wire-derived Anys" | Added `require.Nil(t, any.GetCachedValue())` after roundtrip in the new adversarial probes |
| 3 | "Bare-registry negative control is too broad — could fail for unrelated reasons" | Added `*WithoutStakingOnly` + `*WithoutDistributionOnly` that register baseline-minus-one and assert failure cites the exact typeUrl |
| 4 | "Probe hand-wires SDK; doesn't exercise `tx_indexer.Chains()` factory" | Added `TestProbe_ProductionFactoryPath` calling the actual production factory |
| 5 | "Probe trusts hardcoded fixture txids; doesn't prove provenance" | Added `TestProbe_FixtureProvenance` asserting SHA256(fixture) == claimed txid |
| 6 | "`stripSignerInfo` produces a synthetic shape (no signer_infos, sequence-defaults-to-0)" | Acknowledged. The CI test in this PR uses the same shape. The contract being tested is "indexer accepts unsigned bodies", which holds for both. Production wallet sends pre-signing equivalents that match. |
| 7 | "Field assertions narrower than 'fields match LCD' claim" | withdraw_rewards has no amount field by design (per `cosmos.distribution.v1beta1.proto`); thor/maya now check memo + signer + coin_amount + asset.Chain + asset.Ticker |

### Caveats / non-goals

- The probe does NOT broadcast txs — it consumes already-on-chain bytes and verifies the indexer can decode/hash them.
- The probe does NOT prove the indexer's policy-evaluation downstream consumers (those are out of scope for this PR — verifier#581 is purely about the registry knowing the typeUrls).
- The probe lives in `/tmp/verifier-indexer-probe/` (QA-only, not committed). It was run on 2026-05-01 against the PR HEAD `a606f37` with `recipes` pinned at `475ad1fe`.

Probe artifacts captured at `/tmp/verifier-indexer-probe/`:
- `probe_test.go` — the 10 probes
- `fixtures/*.bin` — the 4 real on-chain raw tx bytes
- `fixtures/*.json` — the LCD JSON responses for cross-reference
- `probe-output.txt` — full `go test -v` output
- `codex-adversarial-output.txt` — full codex 5.4 dual-review transcript

Robot-generated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Promoted and updated core module dependency declarations for improved compatibility and stability (Cosmos SDK and related libraries).
* **Tests**
  * Expanded test coverage for transaction hashing, message decoding, determinism, multi-message transactions, and cross-ecosystem message handling to strengthen indexer correctness and interoperability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->