### PR TITLE
fix(verifier): fail-fast on missing/weak JWT secret (token-forgery P0)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,7 +74,7 @@ jobs:
             "server": {
               "host": "localhost",
               "port": 8080,
-              "jwt_secret": "test-secret"
+              "jwt_secret": "ci-only-jwt-secret-not-for-prod-000000000000"
             },
             "redis": {
               "host": "localhost",

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ PLUGIN_ASSETS_REGION ?= us-east-1
 # vcli defaults for integration tests
 DATABASE_DSN ?= postgres://vultisig:vultisig@localhost:5432/vultisig-verifier?sslmode=disable
 ENCRYPTION_SECRET ?= dev-encryption-secret-32b
-JWT_SECRET ?= devsecret
+JWT_SECRET ?= local-dev-only-jwt-secret-not-for-prod-0000
 
 .PHONY: up up-dev down down-dev build build-dev seed-db run-server run-worker run-portal dump-schema test-integration test-portal itest
 
@@ -59,7 +59,7 @@ itest: test-integration
 
 # Portal integration test defaults
 PORTAL_URL ?= http://localhost:8081
-PORTAL_JWT_SECRET ?= test-portal-secret
+PORTAL_JWT_SECRET ?= local-dev-only-portal-jwt-secret-not-prod
 MAX_API_KEYS_PER_PLUGIN ?= 5
 
 test-portal:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -64,6 +64,7 @@ services:
       PLUGIN_ASSETS_SECRET: minioadmin
       PLUGIN_ASSETS_PUBLIC_BASE_URL: http://localhost:9000/vultisig-plugin-assets
       DATABASE_DSN: postgres://myuser:mypassword@postgres:5432/vultisig-verifier?sslmode=disable
+      SERVER_JWT_SECRET: local-dev-only-jwt-secret-not-for-prod-0000
     ports:
       - "8080:8080"
     depends_on:
@@ -86,6 +87,7 @@ services:
       REDIS_PORT: 6379
       BLOCK_STORAGE_HOST: http://minio:9000
       DATABASE_DSN: postgres://myuser:mypassword@postgres:5432/vultisig-verifier?sslmode=disable
+      SERVER_JWT_SECRET: local-dev-only-jwt-secret-not-for-prod-0000
     depends_on:
       postgres:
         condition: service_healthy

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -97,7 +97,10 @@ func NewServer(
 		logrus.Fatalf("Failed to initialize fee service: %v", err)
 	}
 
-	authService := service.NewAuthService(jwtSecret, db, logrus.WithField("service", "auth-service").Logger)
+	authService, err := service.NewAuthService(jwtSecret, db, logrus.WithField("service", "auth-service").Logger)
+	if err != nil {
+		logrus.Fatalf("Failed to initialize auth service: %v", err)
+	}
 
 	reportService, err := service.NewReportService(db, syncer, logrus.WithField("service", "report-service").Logger)
 	if err != nil {

--- a/internal/portal/auth.go
+++ b/internal/portal/auth.go
@@ -29,8 +29,24 @@ type PortalAuthService struct {
 	logger    *logrus.Logger
 }
 
-// NewPortalAuthService creates a new portal authentication service
+// portalMinJWTSecretLen is the minimum acceptable HS256 signing-secret length —
+// same floor as the verifier AuthService (and the agent-backend JWT_SECRET).
+const portalMinJWTSecretLen = 32
+
+// NewPortalAuthService creates a new portal authentication service. It FAILS
+// FAST (fatal) if the JWT secret is missing or too short: jwt_secret is
+// omitempty in the portal config, and an empty secret meant HS256 tokens were
+// signed AND validated with a zero-length key — token forgery for any vault.
+// Fatal (rather than returning an error) because the surrounding NewServer is a
+// struct-literal constructor with no error return, and a forgeable auth service
+// must never boot.
 func NewPortalAuthService(secret string, logger *logrus.Logger) *PortalAuthService {
+	if len(secret) < portalMinJWTSecretLen {
+		if secret == "" {
+			logger.Fatalf("portal auth: jwt_secret is not configured — set a strong (>= %d random bytes) jwt_secret; an empty secret allows token forgery for any vault", portalMinJWTSecretLen)
+		}
+		logger.Fatalf("portal auth: jwt_secret must be at least %d characters (got %d)", portalMinJWTSecretLen, len(secret))
+	}
 	return &PortalAuthService{
 		jwtSecret: []byte(secret),
 		logger:    logger.WithField("service", "portal-auth").Logger,

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -53,13 +54,28 @@ type AuthService struct {
 	logger    *logrus.Logger
 }
 
-// NewAuthService creates a new authentication service
-func NewAuthService(secret string, db storage.DatabaseStorage, logger *logrus.Logger) *AuthService {
+// minJWTSecretLen is the minimum acceptable length for the HS256 signing
+// secret. Mirrors the agent-backend requirement (JWT_SECRET >= 32 chars) so the
+// two services have the same brute-force/forgery floor.
+const minJWTSecretLen = 32
+
+// NewAuthService creates a new authentication service. It FAILS if the JWT
+// secret is missing or too short: `jwt_secret` is `omitempty` in the verifier
+// config, and an empty secret meant HS256 tokens were signed AND validated with
+// a zero-length key — letting anyone forge a token for any public_key. We
+// fail-fast at startup instead of silently shipping a forgeable verifier.
+func NewAuthService(secret string, db storage.DatabaseStorage, logger *logrus.Logger) (*AuthService, error) {
+	if len(secret) < minJWTSecretLen {
+		if secret == "" {
+			return nil, fmt.Errorf("auth: jwt_secret is not configured — set a strong (>= %d random bytes) server.jwt_secret; an empty secret allows token forgery for any vault", minJWTSecretLen)
+		}
+		return nil, fmt.Errorf("auth: jwt_secret must be at least %d characters (got %d)", minJWTSecretLen, len(secret))
+	}
 	return &AuthService{
 		JWTSecret: []byte(secret),
 		db:        db,
 		logger:    logger.WithField("service", "auth").Logger,
-	}
+	}, nil
 }
 
 // generateTokenID generates a random token ID

--- a/internal/service/auth_test.go
+++ b/internal/service/auth_test.go
@@ -22,6 +22,25 @@ import (
 
 const testPublicKey = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
 
+// newAuthServiceForTest constructs an AuthService for tests, asserting no error.
+// NewAuthService now validates the secret length (>= 32), so the helper pads any
+// shorter test secret up to the minimum while preserving its identity prefix —
+// this keeps same-secret/different-secret test semantics intact (a "wrong-secret"
+// still differs from the right one) without every test inlining a 32-char literal.
+// Tests that specifically exercise rejection of a short/empty secret call
+// service.NewAuthService directly and assert the error.
+func newAuthServiceForTest(t *testing.T, secret string, db storage.DatabaseStorage) *service.AuthService {
+	t.Helper()
+	if len(secret) < 32 {
+		secret = secret + "-padded-to-min-length-0000000000000000"
+	}
+	auth, err := service.NewAuthService(secret, db, testLogger)
+	if err != nil {
+		t.Fatalf("NewAuthService: %v", err)
+	}
+	return auth
+}
+
 var testLogger = logrus.New()
 
 var _ storage.DatabaseStorage = (*MockDatabaseStorage)(nil)
@@ -490,6 +509,32 @@ func (m *MockDatabaseStorage) IsProposedPluginApproved(ctx context.Context, plug
 	return args.Bool(0), args.Error(1)
 }
 
+func TestNewAuthService_RejectsWeakSecret(t *testing.T) {
+	mockDB := new(MockDatabaseStorage)
+	cases := []struct {
+		name      string
+		secret    string
+		wantError bool
+	}{
+		{name: "empty secret rejected", secret: "", wantError: true},
+		{name: "short secret rejected", secret: "too-short", wantError: true},
+		{name: "31 chars rejected", secret: "0123456789012345678901234567890", wantError: true},
+		{name: "32 chars accepted", secret: "01234567890123456789012345678901", wantError: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			auth, err := service.NewAuthService(tc.secret, mockDB, testLogger)
+			if tc.wantError {
+				assert.Error(t, err, "weak secret must be rejected to prevent token forgery")
+				assert.Nil(t, auth)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, auth)
+			}
+		})
+	}
+}
+
 func TestGenerateTokenPair(t *testing.T) {
 	testCases := []struct {
 		name          string
@@ -513,7 +558,7 @@ func TestGenerateTokenPair(t *testing.T) {
 				PublicKey: tt.publicKey,
 			}, nil)
 
-			auth := service.NewAuthService(tt.secret, mockDB, testLogger)
+			auth := newAuthServiceForTest(t, tt.secret, mockDB)
 			tokenPair, err := auth.GenerateTokenPair(context.Background(), tt.publicKey)
 
 			if tt.expectedError {
@@ -571,7 +616,7 @@ func TestValidateToken(t *testing.T) {
 				}, nil)
 				mockDB.On("UpdateVaultTokenLastUsed", mock.Anything, mock.Anything).Return(nil)
 
-				auth := service.NewAuthService(secret, mockDB, testLogger)
+				auth := newAuthServiceForTest(t, secret, mockDB)
 				tokenPair, _ := auth.GenerateTokenPair(context.Background(), "test-public-key")
 				return tokenPair.RefreshToken
 			},
@@ -623,7 +668,7 @@ func TestValidateToken(t *testing.T) {
 				mockDB.On("GetVaultToken", mock.Anything, mock.Anything).Return(nil, nil)
 				mockDB.On("UpdateVaultTokenLastUsed", mock.Anything, mock.Anything).Return(nil)
 
-				auth := service.NewAuthService(secret, mockDB, testLogger)
+				auth := newAuthServiceForTest(t, secret, mockDB)
 				tokenPair, _ := auth.GenerateTokenPair(context.Background(), "test-public-key")
 				return tokenPair.RefreshToken
 			},
@@ -649,7 +694,7 @@ func TestValidateToken(t *testing.T) {
 			}, nil)
 			mockDB.On("UpdateVaultTokenLastUsed", mock.Anything, mock.Anything).Return(nil)
 
-			authService := service.NewAuthService(tc.secret, mockDB, testLogger)
+			authService := newAuthServiceForTest(t, tc.secret, mockDB)
 
 			claims, err := authService.ValidateToken(context.Background(), tokenString)
 
@@ -690,7 +735,7 @@ func TestRefreshToken(t *testing.T) {
 					}, nil)
 				mockDB.On("UpdateVaultTokenLastUsed", mock.Anything, tokenID).Return(nil)
 
-				auth := service.NewAuthService(secret, mockDB, testLogger)
+				auth := newAuthServiceForTest(t, secret, mockDB)
 				tokenPair, _ := auth.GenerateTokenPair(context.Background(), testPublicKey)
 				return tokenPair.RefreshToken
 			},
@@ -754,7 +799,7 @@ func TestRefreshToken(t *testing.T) {
 				mockDB.On("UpdateVaultTokenLastUsed", mock.Anything, mock.Anything).Return(nil)
 			}
 
-			authService := service.NewAuthService(secret, mockDB, testLogger)
+			authService := newAuthServiceForTest(t, secret, mockDB)
 			tokenPair, err := authService.RefreshToken(context.Background(), tokenString)
 
 			if tc.shouldError {

--- a/testdata/integration/portal/portal_test.go
+++ b/testdata/integration/portal/portal_test.go
@@ -31,7 +31,7 @@ var (
 
 func TestMain(m *testing.M) {
 	portalURL = getEnv("PORTAL_URL", "http://localhost:8081")
-	portalJWTSecret = getEnv("PORTAL_JWT_SECRET", "test-portal-secret")
+	portalJWTSecret = getEnv("PORTAL_JWT_SECRET", "test-portal-jwt-secret-min-32-chars-000")
 	testPluginID = getEnv("TEST_PLUGIN_ID", "vultisig-dca-0000")
 
 	dsn := getEnv("DATABASE_DSN", "")

--- a/verifier.example.json
+++ b/verifier.example.json
@@ -6,7 +6,7 @@
   "server": {
     "host": "127.0.0.1",
     "port": 8080,
-    "jwt_secret": "mysecret"
+    "jwt_secret": "local-dev-only-jwt-secret-not-for-prod-0000"
   },
   "database": {
     "dsn": "postgres://myuser:mypassword@localhost:5432/vultisig-verifier?sslmode=disable"


### PR DESCRIPTION
## Fail-fast on a missing/weak verifier JWT secret (token-forgery P0)

### The bug
`NewAuthService` (`internal/service/auth.go`) and `NewPortalAuthService` (`internal/portal/auth.go`) both stored `[]byte(secret)` with **zero validation**, and `jwt_secret` is `omitempty` in the config. So an unset (or trivially short) secret meant HS256 tokens were **signed AND validated with a zero-length key** — letting anyone forge a token for **any** `public_key` and bypass vault-ownership auth on every protected route.

The agent-backend already guards this (`JWT_SECRET required:"true"` + a `>= 32` length check in its config `Validate()`); the verifier and portal did not — an asymmetry surfaced during a stack security audit.

### The fix
- `NewAuthService` now returns `(*AuthService, error)` and **fails** if the secret is empty or `< 32` chars (mirroring the backend floor); `server.go` `logrus.Fatalf`s on that error.
- `NewPortalAuthService` gets the same `>= 32` floor (fatal internally, since its `NewServer` is a struct-literal constructor with no error return — a forgeable auth service must never boot).
- Dev/CI configs that used short secrets (`verifier.example.json` `mysecret`, the CI workflow `test-secret`, `Makefile` `devsecret`/`test-portal-secret`, the portal test fixture) bumped to clearly-non-production `>= 32`-char values; `SERVER_JWT_SECRET` added to both `docker-compose.yaml` verifier services.

### Verification (codex-reviewed)
A codex review of the first commit caught (and this PR fixes) two things that would otherwise have shipped broken: the **identical gap in the portal auth**, and the **dev/CI startup breakage** from the new validation rejecting the old short secrets.

## receipts
This is a backend security fix — no UI. Receipt = the new rejection test + build/lint:

```
$ go test ./internal/service/ -run TestNewAuthService_RejectsWeakSecret
# asserts: empty + "too-short" + 31-char secrets are REJECTED; a 32-char secret is accepted.
```
- `TestNewAuthService_RejectsWeakSecret` (new) pins the validation.
- Existing auth suite updated via a `newAuthServiceForTest` helper that pads short test secrets to the new minimum while preserving the right-vs-wrong-secret distinctness in the `ValidateToken` tests.
- `gofmt`/parse clean on all changed Go files; YAML + JSON configs validated.

> Note: the local toolchain is Go 1.26 but this repo targets `go 1.25` (a vendored `bytedance/sonic@v1.14.2` is incompatible with Go 1.26's runtime internals — `undefined: GoMapIterator`), so the package test suite can't be run locally; CI (Go 1.25) exercises it. The changed Go files compile and gofmt-validate in isolation.

### Out of scope (tracked separately)
The `auth.enabled=false` production-disable gap (`internal/api/middleware.go:42`) and the cosmos-signing verifier bypass are separate findings from the same audit, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
