### PR TITLE
feat: freedom co-signer policy gate (stage 1, shadow mode)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -50,6 +50,14 @@ type VerifierConfig struct {
 	Service      struct {
 		Key string `mapstructure:"key" json:"key,omitempty"`
 	} `mapstructure:"service" json:"service,omitempty"`
+	Freedom FreedomConfig `mapstructure:"freedom" json:"freedom,omitempty"`
+}
+
+// FreedomConfig controls the freedom co-signer policy gate.
+type FreedomConfig struct {
+	// Enforce gates signing on policy evaluation. When false (default), policy
+	// misses are logged but signing proceeds (shadow mode for safe rollout).
+	Enforce bool `mapstructure:"enforce" json:"enforce,omitempty"`
 }
 
 type FeesConfig struct {

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/vultisig/commondata v0.0.0-20250710214228-61d9ed8f7778
 	github.com/vultisig/go-wrappers v0.0.0-20260116015747-e12e4d06cf57
 	github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74
-	github.com/vultisig/recipes v0.0.0-20260503115421-d28b3880fd08
+	github.com/vultisig/recipes v0.0.0-20260630135030-60491d12e1c5
 	github.com/vultisig/vultiserver v0.0.0-20250825042420-c6e6ac281110
 	github.com/vultisig/vultisig-go v0.0.0-20260114092710-6c38516a0c85
 	github.com/xyield/xrpl-go v0.0.0-20230914223425-9abe75c05830
@@ -78,8 +78,8 @@ require (
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f // indirect
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic v1.14.2 // indirect
-	github.com/bytedance/sonic/loader v0.4.0 // indirect
+	github.com/bytedance/sonic v1.15.2 // indirect
+	github.com/bytedance/sonic/loader v0.5.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,12 @@ github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
 github.com/bytedance/sonic v1.14.2 h1:k1twIoe97C1DtYUo+fZQy865IuHia4PR5RPiuGPPIIE=
 github.com/bytedance/sonic v1.14.2/go.mod h1:T80iDELeHiHKSc0C9tubFygiuXoGzrkjKzX2quAx980=
+github.com/bytedance/sonic v1.15.2 h1:90H+rcF/FwLXwfB1cudOLq/je83n683Utf4Cbp0xHCo=
+github.com/bytedance/sonic v1.15.2/go.mod h1:mT2NbXunuaEbnZ+mRIX/vYqKISmgEuHFDI4UzmKx2SA=
 github.com/bytedance/sonic/loader v0.4.0 h1:olZ7lEqcxtZygCK9EKYKADnpQoYkRQxaeY2NYzevs+o=
 github.com/bytedance/sonic/loader v0.4.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
+github.com/bytedance/sonic/loader v0.5.1 h1:Ygpfa9zwRCCKSlrp5bBP/b/Xzc3VxsAW+5NIYXrOOpI=
+github.com/bytedance/sonic/loader v0.5.1/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
@@ -1050,6 +1054,10 @@ github.com/vultisig/recipes v0.0.0-20260430121755-475ad1fe90db h1:hYjpUTaFVqJWVW
 github.com/vultisig/recipes v0.0.0-20260430121755-475ad1fe90db/go.mod h1:PUz2BoPkuCrk9EFeWavynFSIMM2DNULfFeSS0CGVIVc=
 github.com/vultisig/recipes v0.0.0-20260503115421-d28b3880fd08 h1:GiZ9OfXAJst6+9ee73QxxfSqItbWB6HhmDQ79lx//cc=
 github.com/vultisig/recipes v0.0.0-20260503115421-d28b3880fd08/go.mod h1:PUz2BoPkuCrk9EFeWavynFSIMM2DNULfFeSS0CGVIVc=
+github.com/vultisig/recipes v0.0.0-20260630134044-dd424d53c9e0 h1:F7w9KET9y7BRIKGFxkttWWWF/q4YQHkoTIGg+cVOCWw=
+github.com/vultisig/recipes v0.0.0-20260630134044-dd424d53c9e0/go.mod h1:PUz2BoPkuCrk9EFeWavynFSIMM2DNULfFeSS0CGVIVc=
+github.com/vultisig/recipes v0.0.0-20260630135030-60491d12e1c5 h1:eumnPl9TnRxWDLg5fXC3xMLGvb1+oliEvZK2a+1GLuc=
+github.com/vultisig/recipes v0.0.0-20260630135030-60491d12e1c5/go.mod h1:PUz2BoPkuCrk9EFeWavynFSIMM2DNULfFeSS0CGVIVc=
 github.com/vultisig/vultiserver v0.0.0-20250825042420-c6e6ac281110 h1:7WDQ92FAdu08Byjgm3RNS8Sok49sK521PzPcbRpbzCE=
 github.com/vultisig/vultiserver v0.0.0-20250825042420-c6e6ac281110/go.mod h1:HwP2IgW6Mcu/gX8paFuKvfibrGE9UmPgkOFTub6dskM=
 github.com/vultisig/vultisig-go v0.0.0-20260114092710-6c38516a0c85 h1:NAVXp2Mm791Z/teQHUA8T7mhmx3bouyrXvQkLXvAu3M=

--- a/internal/api/freedom.go
+++ b/internal/api/freedom.go
@@ -50,6 +50,24 @@ func (s *Server) FreedomSign(c echo.Context) error {
 	}
 	firstMsg := req.Messages[0]
 
+	// Reject chains the freedom policy doesn't cover — fail-closed in both shadow
+	// and enforce mode. Without this guard, an unrecognised chain (Solana, BTC,
+	// THORChain, …) would reach policy evaluation with zero matching rules:
+	//   - shadow mode: "no matching rule" is treated as a pass → anything gets signed
+	//   - enforce mode: same miss → policy error logged but no explicit rejection here
+	// Fail-closed here so the gate is meaningful regardless of mode.
+	supportedChains := supportedFreedomChains()
+	chainSupported := false
+	for _, sc := range supportedChains {
+		if firstMsg.Chain == sc {
+			chainSupported = true
+			break
+		}
+	}
+	if !chainSupported {
+		return s.badRequest(c, fmt.Sprintf("chain %q is not supported by the freedom policy", firstMsg.Chain), nil)
+	}
+
 	ngn, err := engine.NewEngine()
 	if err != nil {
 		return s.internal(c, "failed to create engine", err)

--- a/internal/api/freedom.go
+++ b/internal/api/freedom.go
@@ -107,6 +107,20 @@ func (s *Server) FreedomSign(c echo.Context) error {
 		s.logger.WithError(policyErr).Warn("freedom policy: tx not allowed (shadow mode, proceeding)")
 	}
 
+	// Verify the freedom vault has been onboarded before enqueuing a keysign.
+	// Mirrors the existence gate in validateAndSign (plugin.go). Without this,
+	// a valid JWT for a not-yet-onboarded vault would queue a keysign that the
+	// worker would fail to execute, burning a signing slot and polluting the
+	// tx indexer.
+	vaultFile := common.GetVaultBackupFilename(req.PublicKey, FreedomPluginID)
+	vaultExists, err := s.vaultStorage.Exist(vaultFile)
+	if err != nil {
+		return s.internal(c, "failed to check freedom vault existence", err)
+	}
+	if !vaultExists {
+		return c.JSON(http.StatusNotFound, NewErrorResponseWithMessage("freedom vault not found — vault must be onboarded before signing"))
+	}
+
 	// Track the transaction.
 	txToTrack, err := s.txIndexerService.CreateTx(c.Request().Context(), storage.CreateTxDto{
 		PluginID:      vtypes.PluginID(req.PluginID),

--- a/internal/api/freedom.go
+++ b/internal/api/freedom.go
@@ -1,0 +1,147 @@
+package api
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/hibiken/asynq"
+	"github.com/labstack/echo/v4"
+	"github.com/vultisig/recipes/engine"
+	"github.com/vultisig/verifier/plugin/tasks"
+	"github.com/vultisig/verifier/plugin/tx_indexer/pkg/storage"
+	vtypes "github.com/vultisig/verifier/types"
+	"github.com/vultisig/vultisig-go/common"
+)
+
+// FreedomSign is the co-signer handler for the freedom signing surface.
+//
+// Design:
+//   - Authenticated via JWT (VaultAuthMiddleware) — the signer's public key is
+//     extracted from the token, NOT from the request body.
+//   - The freedom policy (FreedomPolicy) is evaluated against the proposed tx.
+//     When cfg.Freedom.Enforce is true (tests / opt-in prod), a policy miss → 403.
+//     When false (default shadow mode), the policy miss is logged but signing
+//     proceeds — allows ramping the gate without blocking users.
+//   - PluginID is hardcoded to FreedomPluginID; the client cannot override it.
+//   - Hash derivation mirrors validateAndSign: the verifier derives hashes from
+//     txBytes independently, preventing the "bytes X, hash Y" substitution attack.
+func (s *Server) FreedomSign(c echo.Context) error {
+	// Public key from JWT — authenticated, not client-controlled.
+	publicKey, ok := c.Get("vault_public_key").(string)
+	if !ok || publicKey == "" {
+		return c.JSON(http.StatusUnauthorized, NewErrorResponseWithMessage(msgUnauthorized))
+	}
+
+	var req vtypes.PluginKeysignRequest
+	if err := c.Bind(&req); err != nil {
+		return s.badRequest(c, msgRequestParseFailed, err)
+	}
+
+	// Override with server-derived values — never trust the client for these.
+	req.PublicKey = publicKey
+	req.PluginID = FreedomPluginID
+
+	if len(req.Messages) == 0 {
+		return s.badRequest(c, msgNoMessagesToSign, nil)
+	}
+	firstMsg := req.Messages[0]
+
+	ngn, err := engine.NewEngine()
+	if err != nil {
+		return s.internal(c, "failed to create engine", err)
+	}
+
+	// Extract tx bytes using the chain-specific handler.
+	txBytesEvaluate, err := ngn.ExtractTxBytes(firstMsg.Chain, req.Transaction)
+	if err != nil {
+		return s.badRequest(c, "failed to extract transaction bytes", err)
+	}
+
+	// Derive signing hashes from the verified tx bytes — ignores any client-provided hashes.
+	derivedHashes, err := deriveSigningHashes(firstMsg.Chain, txBytesEvaluate, req.Transaction, req.SignBytes)
+	if err != nil {
+		return s.badRequest(c, "failed to derive signing hash", err)
+	}
+
+	if len(derivedHashes) != len(req.Messages) {
+		return s.badRequest(c, fmt.Sprintf("expected %d messages for %d derived hashes, got %d messages",
+			len(derivedHashes), len(derivedHashes), len(req.Messages)), nil)
+	}
+
+	// Replace client hashes with verifier-derived values.
+	for i := range req.Messages {
+		req.Messages[i].Message = base64.StdEncoding.EncodeToString(derivedHashes[i].Message)
+		req.Messages[i].Hash = base64.StdEncoding.EncodeToString(derivedHashes[i].Hash)
+		req.Messages[i].HashFunction = vtypes.HashFunction_SHA256
+	}
+
+	// Evaluate the freedom policy.
+	_, policyErr := ngn.Evaluate(FreedomPolicy, firstMsg.Chain, txBytesEvaluate)
+	if policyErr != nil {
+		if s.cfg.Freedom.Enforce {
+			return s.forbidden(c, msgTxNotAllowed, policyErr)
+		}
+		// Shadow mode: log but proceed.
+		s.logger.WithError(policyErr).Warn("freedom policy: tx not allowed (shadow mode, proceeding)")
+	}
+
+	// Track the transaction.
+	txToTrack, err := s.txIndexerService.CreateTx(c.Request().Context(), storage.CreateTxDto{
+		PluginID:      vtypes.PluginID(req.PluginID),
+		ChainID:       firstMsg.Chain,
+		PolicyID:      uuid.Nil,
+		TokenID:       "",
+		FromPublicKey: req.PublicKey,
+		ToPublicKey:   "",
+		ProposedTxHex: req.Transaction,
+		Amount:        "",
+	})
+	if err != nil {
+		return s.internal(c, "failed to create tx for tracking", err)
+	}
+	req.Messages[0].TxIndexerID = txToTrack.ID.String()
+
+	if err := s.txIndexerService.SetStatus(c.Request().Context(), txToTrack.ID, storage.TxVerified); err != nil {
+		return s.internal(c, fmt.Sprintf("tx_id=%s, failed to set transaction status to verified", txToTrack.ID), err)
+	}
+
+	// Deduplicate by session ID (idempotent re-submissions return 200).
+	result, err := s.redis.Get(c.Request().Context(), req.SessionID)
+	if err == nil && result != "" {
+		return c.NoContent(http.StatusOK)
+	}
+
+	if err := s.redis.Set(c.Request().Context(), req.SessionID, req.SessionID, 30*time.Minute); err != nil {
+		s.logger.WithError(err).Error("fail to set session")
+	}
+
+	buf, err := json.Marshal(req)
+	if err != nil {
+		return s.badRequest(c, "fail to marshal to json", err)
+	}
+
+	ti, err := s.asynqClient.EnqueueContext(c.Request().Context(),
+		asynq.NewTask(tasks.TypeKeySignDKLS, buf),
+		asynq.MaxRetry(0),
+		asynq.Timeout(2*time.Minute),
+		asynq.Retention(5*time.Minute),
+		asynq.Queue(tasks.QUEUE_NAME))
+	if err != nil {
+		return s.internal(c, "fail to enqueue keysign task", err)
+	}
+
+	return c.JSON(http.StatusOK, NewSuccessResponse(http.StatusOK, map[string][]string{
+		"task_ids": {ti.ID},
+	}))
+}
+
+// supportedFreedomChains returns the set of chains the freedom policy covers.
+// Only chains with matching rules in FreedomPolicy are included; requests for
+// other chains will fail policy evaluation.
+func supportedFreedomChains() []common.Chain {
+	return []common.Chain{common.Ethereum}
+}

--- a/internal/api/freedom_policy.go
+++ b/internal/api/freedom_policy.go
@@ -104,9 +104,15 @@ var FreedomPolicy = &rtypes.Policy{
 			},
 		},
 
-		// Allow USDC ERC-20 approvals up to uint256.max - 1 (any spender).
-		// The DENY rule above catches the exact uint256.max boundary; this rule
-		// covers all sub-max approvals for legitimate DApp integrations.
+		// Allow USDC ERC-20 approvals up to $10 (10_000_000, 6 decimals) — matching
+		// the transfer cap exactly. The freedom use case (approve + aave supply bundle)
+		// requires a bounded approve equal to the deposit amount, so a $10 ceiling
+		// covers every legitimate flow while bounding the blast radius to $10.
+		//
+		// IMPORTANT: the previous ceiling was uint256.max-1, which let a compromised
+		// agent issue approve(drainer, ~∞) and then transferFrom the entire balance.
+		// The DENY-uint256.max rule is intentionally kept as a belt-and-suspenders
+		// backstop, but the primary protection is now this tight MaxValue cap.
 		{
 			Id:       "allow-usdc-approve",
 			Resource: "ethereum.erc20.approve",
@@ -123,11 +129,8 @@ var FreedomPolicy = &rtypes.Policy{
 				{
 					ParameterName: "amount",
 					Constraint: &rtypes.Constraint{
-						Type: rtypes.ConstraintType_CONSTRAINT_TYPE_MAX,
-						// uint256.max - 1 so that uint256.max is caught by the DENY rule above.
-						Value: &rtypes.Constraint_MaxValue{
-							MaxValue: new(big.Int).Sub(uint256Max, big.NewInt(1)).String(),
-						},
+						Type:  rtypes.ConstraintType_CONSTRAINT_TYPE_MAX,
+						Value: &rtypes.Constraint_MaxValue{MaxValue: "10000000"}, // $10 USDC (6 decimals)
 					},
 				},
 			},

--- a/internal/api/freedom_policy.go
+++ b/internal/api/freedom_policy.go
@@ -1,0 +1,136 @@
+package api
+
+import (
+	"math/big"
+
+	rtypes "github.com/vultisig/recipes/types"
+)
+
+// FreedomPluginID is the synthetic plugin identifier used for freedom signing.
+// Freedom vaults are stored under this key on VultiServer.
+const FreedomPluginID = "vultisig.freedom"
+
+// usdcAddress is the canonical USDC contract address on Ethereum mainnet.
+const usdcAddress = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+
+// uint256Max is 2^256 - 1.
+var uint256Max, _ = new(big.Int).SetString(
+	"115792089237316195423570985008687907853269984665640564039457584007913129639935", 10,
+)
+
+// FreedomPolicy is the static co-signer policy for the freedom signing surface.
+//
+// Design intent:
+//   - DENY rules fire first (deny-wins semantics in the recipes engine).
+//   - ALLOW rules define the permitted set within those limits.
+//   - Every ALLOW rule that names a specific contract targets that contract via
+//     TARGET_TYPE_ADDRESS; native ETH transfers use TARGET_TYPE_UNSPECIFIED
+//     (any recipient, amount-capped).
+var FreedomPolicy = &rtypes.Policy{
+	Id:   "vultisig.freedom.v1",
+	Name: "Freedom Policy v1",
+	Rules: []*rtypes.Rule{
+		// --- DENY rules (evaluated first) ---
+
+		// Reject unbounded ERC-20 USDC approvals (amount == uint256.max).
+		// A legitimate DApp should never need unlimited approval; this blocks
+		// a class of approval-draining attacks.
+		{
+			Id:       "deny-usdc-approve-unbounded",
+			Resource: "ethereum.erc20.approve",
+			Effect:   rtypes.Effect_EFFECT_DENY,
+			Target: &rtypes.Target{
+				TargetType: rtypes.TargetType_TARGET_TYPE_ADDRESS,
+				Target:     &rtypes.Target_Address{Address: usdcAddress},
+			},
+			ParameterConstraints: []*rtypes.ParameterConstraint{
+				{
+					ParameterName: "spender",
+					Constraint:    &rtypes.Constraint{Type: rtypes.ConstraintType_CONSTRAINT_TYPE_ANY},
+				},
+				{
+					ParameterName: "amount",
+					Constraint: &rtypes.Constraint{
+						Type:  rtypes.ConstraintType_CONSTRAINT_TYPE_FIXED,
+						Value: &rtypes.Constraint_FixedValue{FixedValue: uint256Max.String()},
+					},
+				},
+			},
+		},
+
+		// --- ALLOW rules ---
+
+		// Allow native ETH transfers up to 0.01 ETH (1e16 wei) to any recipient.
+		{
+			Id:       "allow-eth-transfer",
+			Resource: "ethereum.eth.transfer",
+			Effect:   rtypes.Effect_EFFECT_ALLOW,
+			Target: &rtypes.Target{
+				// TARGET_TYPE_UNSPECIFIED = no recipient restriction.
+				TargetType: rtypes.TargetType_TARGET_TYPE_UNSPECIFIED,
+			},
+			ParameterConstraints: []*rtypes.ParameterConstraint{
+				{
+					ParameterName: "amount",
+					Constraint: &rtypes.Constraint{
+						Type:  rtypes.ConstraintType_CONSTRAINT_TYPE_MAX,
+						Value: &rtypes.Constraint_MaxValue{MaxValue: "10000000000000000"}, // 0.01 ETH
+					},
+				},
+			},
+		},
+
+		// Allow USDC ERC-20 transfers up to $10 (1e7, 6 decimals) to any recipient.
+		{
+			Id:       "allow-usdc-transfer",
+			Resource: "ethereum.erc20.transfer",
+			Effect:   rtypes.Effect_EFFECT_ALLOW,
+			Target: &rtypes.Target{
+				TargetType: rtypes.TargetType_TARGET_TYPE_ADDRESS,
+				Target:     &rtypes.Target_Address{Address: usdcAddress},
+			},
+			ParameterConstraints: []*rtypes.ParameterConstraint{
+				{
+					ParameterName: "recipient",
+					Constraint:    &rtypes.Constraint{Type: rtypes.ConstraintType_CONSTRAINT_TYPE_ANY},
+				},
+				{
+					ParameterName: "amount",
+					Constraint: &rtypes.Constraint{
+						Type:  rtypes.ConstraintType_CONSTRAINT_TYPE_MAX,
+						Value: &rtypes.Constraint_MaxValue{MaxValue: "10000000"}, // $10 USDC
+					},
+				},
+			},
+		},
+
+		// Allow USDC ERC-20 approvals up to uint256.max - 1 (any spender).
+		// The DENY rule above catches the exact uint256.max boundary; this rule
+		// covers all sub-max approvals for legitimate DApp integrations.
+		{
+			Id:       "allow-usdc-approve",
+			Resource: "ethereum.erc20.approve",
+			Effect:   rtypes.Effect_EFFECT_ALLOW,
+			Target: &rtypes.Target{
+				TargetType: rtypes.TargetType_TARGET_TYPE_ADDRESS,
+				Target:     &rtypes.Target_Address{Address: usdcAddress},
+			},
+			ParameterConstraints: []*rtypes.ParameterConstraint{
+				{
+					ParameterName: "spender",
+					Constraint:    &rtypes.Constraint{Type: rtypes.ConstraintType_CONSTRAINT_TYPE_ANY},
+				},
+				{
+					ParameterName: "amount",
+					Constraint: &rtypes.Constraint{
+						Type: rtypes.ConstraintType_CONSTRAINT_TYPE_MAX,
+						// uint256.max - 1 so that uint256.max is caught by the DENY rule above.
+						Value: &rtypes.Constraint_MaxValue{
+							MaxValue: new(big.Int).Sub(uint256Max, big.NewInt(1)).String(),
+						},
+					},
+				},
+			},
+		},
+	},
+}

--- a/internal/api/freedom_test.go
+++ b/internal/api/freedom_test.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	"math/big"
+	"testing"
+
+	ecommon "github.com/ethereum/go-ethereum/common"
+	etypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/stretchr/testify/require"
+	"github.com/vultisig/recipes/engine"
+	"github.com/vultisig/recipes/sdk/evm/codegen/erc20"
+	"github.com/vultisig/vultisig-go/common"
+)
+
+// buildTestEvmTx encodes an unsigned EIP-1559 tx for use in gate tests.
+// The resulting bytes are the same format the verifier receives from clients
+// (base64-decoded from req.Transaction after ExtractTxBytes).
+func buildTestEvmTx(to ecommon.Address, data []byte, value *big.Int) []byte {
+	unsigned := struct {
+		ChainID    *big.Int
+		Nonce      uint64
+		GasTipCap  *big.Int
+		GasFeeCap  *big.Int
+		Gas        uint64
+		To         *ecommon.Address `rlp:"nil"`
+		Value      *big.Int
+		Data       []byte
+		AccessList etypes.AccessList
+	}{
+		ChainID:    big.NewInt(1),
+		Nonce:      0,
+		GasTipCap:  big.NewInt(2_000_000_000),  // 2 gwei
+		GasFeeCap:  big.NewInt(20_000_000_000), // 20 gwei
+		Gas:        300_000,
+		To:         &to,
+		Value:      value,
+		Data:       data,
+		AccessList: nil,
+	}
+	payload, err := rlp.EncodeToBytes(unsigned)
+	if err != nil {
+		panic(err)
+	}
+	return append([]byte{etypes.DynamicFeeTxType}, payload...)
+}
+
+// TestFreedomPolicyGate covers the five security cases mandated by the design.
+// FreedomPolicy is evaluated directly (no HTTP / Redis / DB needed) so these
+// tests run without any external infrastructure.
+func TestFreedomPolicyGate(t *testing.T) {
+	t.Parallel()
+
+	ngn, err := engine.NewEngine()
+	require.NoError(t, err)
+
+	usdc := ecommon.HexToAddress(usdcAddress)
+	uint256Max, ok := new(big.Int).SetString(
+		"115792089237316195423570985008687907853269984665640564039457584007913129639935", 10,
+	)
+	require.True(t, ok)
+
+	t.Run("over-cap native transfer is denied", func(t *testing.T) {
+		t.Parallel()
+		// 0.1 ETH = 1e17 wei — exceeds 0.01 ETH cap.
+		recipient := ecommon.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+		tx := buildTestEvmTx(recipient, nil, big.NewInt(1e17))
+		_, err := ngn.Evaluate(FreedomPolicy, common.Ethereum, tx)
+		require.Error(t, err, "0.1 ETH transfer must be denied (cap is 0.01 ETH)")
+	})
+
+	t.Run("unbounded erc20 approve is denied", func(t *testing.T) {
+		t.Parallel()
+		spender := ecommon.HexToAddress("0xabcdef1234567890abcdef1234567890abcdef12")
+		data := erc20.NewErc20().PackApprove(spender, uint256Max)
+		tx := buildTestEvmTx(usdc, data, big.NewInt(0))
+		_, err := ngn.Evaluate(FreedomPolicy, common.Ethereum, tx)
+		require.Error(t, err, "uint256.max approve must be denied by DENY rule")
+		require.Contains(t, err.Error(), "denied")
+	})
+
+	t.Run("garbage tx bytes are rejected", func(t *testing.T) {
+		t.Parallel()
+		// Cannot decode → policy evaluation fails before rule matching.
+		garbage := []byte("this is not a valid rlp evm transaction at all")
+		_, err := ngn.Evaluate(FreedomPolicy, common.Ethereum, garbage)
+		require.Error(t, err, "invalid tx bytes must be rejected")
+	})
+
+	t.Run("non-allowlisted calldata is denied", func(t *testing.T) {
+		t.Parallel()
+		// ERC-20 transfer targeting a contract that is NOT in the policy.
+		// The transfer ALLOW rule targets USDC; a different token contract
+		// will not match TARGET_TYPE_ADDRESS and must be rejected.
+		randomToken := ecommon.HexToAddress("0x1234567890123456789012345678901234567890")
+		data := erc20.NewErc20().PackTransfer(ecommon.HexToAddress("0xdeadbeef"), big.NewInt(1_000_000))
+		tx := buildTestEvmTx(randomToken, data, big.NewInt(0))
+		_, err := ngn.Evaluate(FreedomPolicy, common.Ethereum, tx)
+		require.Error(t, err, "transfer to non-allowlisted token must be denied")
+	})
+
+	t.Run("valid in-cap usdc transfer passes", func(t *testing.T) {
+		t.Parallel()
+		// $1 USDC = 1_000_000 (6 decimals) — well within the $10 cap.
+		recipient := ecommon.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+		data := erc20.NewErc20().PackTransfer(recipient, big.NewInt(1_000_000))
+		tx := buildTestEvmTx(usdc, data, big.NewInt(0))
+		rule, err := ngn.Evaluate(FreedomPolicy, common.Ethereum, tx)
+		require.NoError(t, err, "valid $1 USDC transfer must be allowed")
+		require.NotNil(t, rule)
+		require.Equal(t, "allow-usdc-transfer", rule.GetId())
+	})
+}

--- a/internal/api/freedom_test.go
+++ b/internal/api/freedom_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -43,6 +44,41 @@ func buildTestEvmTx(to ecommon.Address, data []byte, value *big.Int) []byte {
 		panic(err)
 	}
 	return append([]byte{etypes.DynamicFeeTxType}, payload...)
+}
+
+// TestFreedomChainAllowlist verifies that supportedFreedomChains() is accurate
+// and that the engine rejects non-Ethereum chains at policy evaluation time.
+// This is the engine-level complement to the HTTP handler chain guard (P1-1):
+// even if the handler check were bypassed, the policy must produce an error for
+// unsupported chains (no matching rules → evaluation error).
+func TestFreedomChainAllowlist(t *testing.T) {
+	t.Parallel()
+
+	ngn, err := engine.NewEngine()
+	require.NoError(t, err)
+
+	supported := supportedFreedomChains()
+
+	// Solana and Bitcoin have no rules in FreedomPolicy.
+	unsupportedChains := []common.Chain{common.Solana, common.Bitcoin, common.BscChain}
+	for _, chain := range unsupportedChains {
+		chain := chain
+		t.Run(fmt.Sprintf("chain %v not in allowlist", chain), func(t *testing.T) {
+			t.Parallel()
+			for _, sc := range supported {
+				require.NotEqual(t, sc, chain, "chain must not be in supportedFreedomChains")
+			}
+		})
+		t.Run(fmt.Sprintf("chain %v rejected by engine", chain), func(t *testing.T) {
+			t.Parallel()
+			// Use a minimal valid-ish byte slice; the engine should fail on no
+			// matching rule before it even decodes the tx.
+			someBytes := []byte{0x01, 0x02, 0x03}
+			_, evalErr := ngn.Evaluate(FreedomPolicy, chain, someBytes)
+			require.Error(t, evalErr,
+				"engine must reject chain %v: no rules in FreedomPolicy match", chain)
+		})
+	}
 }
 
 // TestFreedomPolicyGate covers the five security cases mandated by the design.
@@ -109,5 +145,54 @@ func TestFreedomPolicyGate(t *testing.T) {
 		require.NoError(t, err, "valid $1 USDC transfer must be allowed")
 		require.NotNil(t, rule)
 		require.Equal(t, "allow-usdc-transfer", rule.GetId())
+	})
+
+	// P1-2 regression: near-infinite approve (uint256.max-1) must be DENIED after
+	// the MaxValue cap was tightened to $10. Before the fix this amount passed
+	// allow-usdc-approve (MaxValue was uint256.max-1); after the fix it must fail.
+	t.Run("near-infinite usdc approve is denied (P1-2 regression)", func(t *testing.T) {
+		t.Parallel()
+		spender := ecommon.HexToAddress("0xabcdef1234567890abcdef1234567890abcdef12")
+		nearMax := new(big.Int).Sub(uint256Max, big.NewInt(1)) // uint256.max - 1
+		data := erc20.NewErc20().PackApprove(spender, nearMax)
+		tx := buildTestEvmTx(usdc, data, big.NewInt(0))
+		_, err := ngn.Evaluate(FreedomPolicy, common.Ethereum, tx)
+		require.Error(t, err, "uint256.max-1 approve must be denied (cap is $10 USDC)")
+	})
+
+	// P1-2 positive: a small in-cap approve (≤ $10) must still be allowed so the
+	// aave deposit bundle (approve exact amount + supply) keeps working.
+	t.Run("small in-cap usdc approve passes (P1-2 positive)", func(t *testing.T) {
+		t.Parallel()
+		spender := ecommon.HexToAddress("0xabcdef1234567890abcdef1234567890abcdef12")
+		// $5 USDC = 5_000_000 (6 decimals) — within the $10 cap.
+		data := erc20.NewErc20().PackApprove(spender, big.NewInt(5_000_000))
+		tx := buildTestEvmTx(usdc, data, big.NewInt(0))
+		rule, err := ngn.Evaluate(FreedomPolicy, common.Ethereum, tx)
+		require.NoError(t, err, "$5 USDC approve must be allowed (cap is $10)")
+		require.NotNil(t, rule)
+		require.Equal(t, "allow-usdc-approve", rule.GetId())
+	})
+
+	// P1-3 calldata guard lock-in: a tx with native value AND ERC-20 calldata must
+	// NOT be allowed by the native-transfer rule. This test locks in the
+	// assertArgsNative guard added in vultisig-recipes commit 60491d1. If that guard
+	// ever regresses, this test will fail and block the merge.
+	//
+	// Attack scenario without the guard:
+	//   tx.to = USDC, tx.value = 0.01 ETH, tx.data = erc20.transfer(attacker, $1M)
+	// The native-transfer rule would see value ≤ cap and allow it, but the calldata
+	// would execute a $1M USDC transfer to the attacker.
+	t.Run("native transfer with calldata is denied (P1-3 calldata guard)", func(t *testing.T) {
+		t.Parallel()
+		recipient := ecommon.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+		// Calldata: transfer $1M USDC to attacker — but the tx has ETH value 0.01
+		// so a naive amount-only check would pass the native-transfer rule.
+		data := erc20.NewErc20().PackTransfer(recipient, big.NewInt(1_000_000_000_000)) // $1M
+		tx := buildTestEvmTx(usdc, data, big.NewInt(1e16))                              // 0.01 ETH value
+		_, err := ngn.Evaluate(FreedomPolicy, common.Ethereum, tx)
+		require.Error(t, err,
+			"tx with ETH value + ERC-20 calldata must NOT pass native-transfer rule; "+
+				"this test guards vultisig-recipes assertArgsNative (commit 60491d1)")
 	})
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -223,6 +223,11 @@ func (s *Server) StartServer() error {
 	pricingsGroup := e.Group("/pricing")
 	pricingsGroup.GET("/:pricingId", s.GetPricing)
 
+	// Freedom signing surface — authenticated via user JWT (VaultAuthMiddleware).
+	// Policy gate enforced based on cfg.Freedom.Enforce (shadow mode by default).
+	freedomGroup := e.Group("/freedom", s.VaultAuthMiddleware)
+	freedomGroup.POST("/sign", s.FreedomSign)
+
 	return e.Start(fmt.Sprintf(":%d", s.cfg.Server.Port))
 }
 


### PR DESCRIPTION
Depends on vultisig/recipes#596.

> **DEPLOY ORDERING (fund-safety critical):** vultisig/recipes#596 (`feat/freedom-deny-support`, commit 60491d1) MUST be merged and bumped in `go.mod` BEFORE or simultaneously with this PR. That commit adds `assertArgsNative` in `engine/evm/evm.go` which rejects native-transfer rules when the tx has calldata. Without it, a tx with `value=0.01ETH` + `data=erc20.transfer(attacker,$1M)` would pass the `allow-eth-transfer` rule — a P0 drain in enforce mode. The current `go.mod` pin (`v0.0.0-20260630135030-60491d12e1c5`) already points to that commit; do NOT downgrade it.

## what

Adds `POST /freedom/sign` — a new signing surface for the agent's code-as-action feature. Users authenticate via JWT (same `VaultAuthMiddleware` as `/auth/me`) and submit EVM tx proposals. The verifier:

1. Rejects chains not in `supportedFreedomChains()` with 400 (fail-closed, shadow + enforce)
2. Extracts and derives hashes from the raw tx bytes (same as plugin signing — prevents the "bytes X, hash Y" substitution attack)
3. Evaluates `FreedomPolicy` against the tx bytes
4. In **shadow mode** (default): logs policy misses, signs anyway — safe ramp
5. In **enforce mode** (`freedom.enforce=true`): 403 on policy miss
6. Checks vault existence before enqueuing (mirrors `validateAndSign`)
7. Tracks the tx via `txIndexerService`, enqueues `TypeKeySignDKLS`

### FreedomPolicy caps (Ethereum mainnet)

| Rule | Type | Details |
|---|---|---|
| deny-usdc-approve-unbounded | DENY | `approve(*, uint256.max)` on USDC blocked |
| allow-eth-transfer | ALLOW | native ETH MAX 0.01 ETH, any recipient |
| allow-usdc-transfer | ALLOW | USDC ERC-20 transfer MAX $10 (1e7 units), any recipient |
| allow-usdc-approve | ALLOW | USDC ERC-20 approve MAX $10 (1e7 units), any spender — bounded to small-value envelope; approve+supply bundle uses exact-amount approves ≤ the deposit |

### Gate tests (`internal/api/freedom_test.go`) — all 14 pass

Existing (5 cases):
1. Over-cap native transfer (0.1 ETH > 0.01 cap) → denied
2. Unbounded USDC approve (uint256.max) → denied by DENY rule
3. Garbage tx bytes → rejected (decode error)
4. Non-allowlisted token transfer → denied (no recipe match)
5. Valid $1 USDC transfer → passes, returns `allow-usdc-transfer` rule

New (9 cases in 2 functions):
- `TestFreedomChainAllowlist`: Solana, Bitcoin, BSC not in allowlist + engine errors on them (no matching rules)
- P1-2 regression: `uint256.max-1` USDC approve → DENIED (would have passed before the cap fix)
- P1-2 positive: $5 USDC approve → ALLOWED (deposit bundles stay working)
- P1-3 calldata guard: ETH value + ERC-20 calldata → NOT allowed by native-transfer rule (locks in `assertArgsNative` from recipes commit 60491d1)

### Also

- `config.FreedomConfig{Enforce bool}` added to `VerifierConfig`
- `bytedance/sonic` v1.14.2→v1.15.2 (pre-existing Go 1.26 build breakage; sonic v1.14.2 has an undefined `GoMapIterator` symbol that blocked all test runs)

## known limitations before enforcement

These are design decisions, not bugs — both must be addressed before flipping `freedom.enforce=true` in production:

- **No per-vault daily spend cap.** The current policy allows up to 0.01 ETH per tx, any number of txs. At the session rate limit (if enforced), the maximum daily drain is bounded by sessions × max-per-tx. A per-vault daily accumulator (e.g. Redis `INCRBY`, 24h TTL) should be added as a pre-enforcement TODO.
- **`TARGET_TYPE_UNSPECIFIED` on native ETH = any recipient.** The `allow-eth-transfer` rule caps *amount* but not *destination*. A compromised agent can send 0.01 ETH to any address repeatedly. This is intentional for the current UX (no whitelist), but means the blast radius for native ETH is unbounded in total (amount-per-tx is bounded). A recipient allowlist or daily accumulator mitigates this.

## open questions / stage 2 todos

- Rate limiting (86400s window, 10 tx max) — defined in design but not implemented in stage 1; the policy eval is the critical gate for now
- Freedom vault share provisioning: the DKLS worker looks up `GetVaultBackupFilename(pubKey, "vultisig.freedom")`; users need a freedom vault share installed before signing works end-to-end
- Multi-chain: policy currently covers Ethereum mainnet only; other EVM chains + Solana follow-up
- Native launch smoke test: CI builds the binary but never does a cold launch — the one check that caught the RN crash pattern

## risk

Low in shadow mode (default). Do NOT flip `freedom.enforce=true` without first merging vultisig/recipes#596 and the two pre-enforcement TODOs above.

🤖 Agent-generated